### PR TITLE
Add missing metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,50 @@ Then run the 'sbom' task on a project:
     ===> Verifying dependencies...
     ===> CycloneDX SBoM written to bom.xml
 
+Configuration
+-------------
+
+You can configure additional SBoM metadata in your `rebar.config`:
+
+    {rebar3_sbom, [
+        {sbom_manufacturer, #{          % Optional
+            name => "Your Organization",
+            address => "Street Address, City",
+            url => "https://example.com"
+        }},
+        {sbom_licenses, ["Apache-2.0"]} % Optional
+    ]}.
+
+**Note:**
+- `sbom_manufacturer` (optional) identifies who is **producing the SBoM document**
+  (typically your organization or CI environment), not necessarily who developed
+  the software. If omitted, the manufacturer field is not included in the SBoM.
+- `sbom_licenses` (optional) specifies the licenses for the **SBoM document itself**
+  (the metadata), not your project. If omitted, it defaults to the same licenses
+  as your project (from the `.app.src` file).
+- Your project's licenses are automatically read from the `.app.src` file and
+  appear in `metadata.component.licenses`.
+
+
+Command Line Options
+--------------------
+
 The following command line options are supported:
 
     -F, --format  the file format of the SBoM output, [xml|json], [default: xml]
     -o, --output  the full path to the SBoM output file [default: ./bom.[xml|json]]
     -f, --force   overwite existing files without prompting for confirmation
                   [default: false]
-    -V, --strict_version modify the version number of the bom only when the content changes
+    -V, --strict_version modify the version number of the BoM only when the content changes
                   [default: true]
-    -a  --author  the author of the SBOM
+    -a  --author  the author of the SBoM
+
+**Author Fallback:** If `--author` is not specified, the plugin will fall back
+to the `GITHUB_ACTOR` environment variable. If that variable isn't set, it will
+use the authors from the project's `.app.src` file.
 
 By default only dependencies in the 'default' profile are included. To
 generate an SBoM covering development environments specify the relevant
 profiles using 'as':
 
     $ rebar3 as default,test,docs sbom -o dev_bom.xml
-
-When no sbom author is specified, the plugin will fallback on the environment variable GITHUB_ACTOR. If that variable isn't set, the plugin will use the same value as for metadata.component.authors.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,22 @@ Configuration
 You can configure additional SBoM metadata in your `rebar.config`:
 
     {rebar3_sbom, [
-        {sbom_manufacturer, #{          % Optional
+        {sbom_manufacturer, #{          % Optional, all fields inside are optional
             name => "Your Organization",
-            address => "Street Address, City",
-            url => "https://example.com"
+            url => "https://example.com",
+            address => #{
+                country => "Country",
+                region => "State",
+                locality => "City",
+                post_office_box_number => "1",
+                postal_code => "12345",
+                street_address => "Street Address"
+            },
+            contact => [
+                #{name => "John Doe",
+                  email => "support@example.com",
+                  phone => "123456789"}
+            ]
         }},
         {sbom_licenses, ["Apache-2.0"]} % Optional
     ]}.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can configure additional SBoM metadata in your `rebar.config`:
     {rebar3_sbom, [
         {sbom_manufacturer, #{          % Optional, all fields inside are optional
             name => "Your Organization",
-            url => "https://example.com",
+            url => ["https://example.com", "https://another-example.com"],
             address => #{
                 country => "Country",
                 region => "State",

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ The following command line options are supported:
                   [default: false]
     -V, --strict_version modify the version number of the bom only when the content changes
                   [default: true]
+    -a  --author  the author of the SBOM
 
 By default only dependencies in the 'default' profile are included. To
 generate an SBoM covering development environments specify the relevant
 profiles using 'as':
 
     $ rebar3 as default,test,docs sbom -o dev_bom.xml
+
+When no sbom author is specified, the plugin will fallback on the environment variable GITHUB_ACTOR. If that variable isn't set, the plugin will use the same value as for metadata.component.authors.

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -1,3 +1,5 @@
+%--- Macros --------------------------------------------------------------------
+
 -define(APP, "rebar3_sbom").
 -define(DEFAULT_OUTPUT, "./bom.[xml|json]").
 -define(DEFAULT_VERSION, 1).
@@ -5,6 +7,68 @@
 -define(DEPS, [lock]).
 -define(SPEC_VERSION, <<"1.6">>).
 
+%--- Types ---------------------------------------------------------------------
+
+-type bom_ref() :: string().
+-type spdx_licence_id() :: string().
+-type properties() :: [{string(), string()}].
+
+%--- Records -------------------------------------------------------------------
+
+-record(address, {
+    bom_ref :: bom_ref(),
+    country :: string(),
+    region :: string(),
+    locality :: string(),
+    post_office_box_number :: string(),
+    postal_code :: string(),
+    street_address :: string()
+}).
+
+-record(contact, {
+    bom_ref :: bom_ref(),
+    name :: string(),
+    email :: string(),
+    phone :: string()
+ }).
+
+% Alias Manufacturer object
+-record(organization, {
+    bom_ref :: bom_ref(),
+    name :: string(),
+    address :: #address{} | undefined,
+    url :: string(),
+    contact :: #contact{} | undefined
+}).
+
+% Alias Author
+-record(individual, {
+    bom_ref :: bom_ref(),
+    name :: string(),
+    email :: string(),
+    phone :: string()
+}).
+
+-record(licensing, {
+    alt_id :: string(),
+    licensor :: #organization{} | #individual{},
+    licensee :: #organization{} | #individual{},
+    purchaser :: #organization{} | #individual{},
+    purchase_order :: string(),
+    licenses_types :: string(),
+    last_renewal :: calendar:datetime(),
+    expiration :: calendar:datetime()
+}).
+
+% Not adding Text or URL for now
+-record(license, {
+    bom_ref :: bom_ref(),
+    id :: spdx_licence_id(),
+    name :: string(),
+    acknowledgement :: string(), % Either "declared" or "concluded",
+    licensing :: #licensing{} | undefined,
+    properties = [] :: properties()
+}).
 
 -record(component, {
     type = "application",
@@ -22,7 +86,8 @@
 -record(metadata, {
     timestamp :: string(),
     component :: #component{},
-    tools = [] :: [string()]
+    tools = [] :: [string()],
+    properties = [] :: properties()
 }).
 
 -record(dependency, {

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -43,10 +43,10 @@
 
 % Alias Author
 -record(individual, {
-    bom_ref :: bom_ref(),
+    bom_ref :: bom_ref() | undefined,
     name :: string(),
-    email :: string(),
-    phone :: string()
+    email :: string() | undefined,
+    phone :: string() | undefined
 }).
 
 -record(licensing, {
@@ -87,6 +87,8 @@
     timestamp :: string(),
     component :: #component{},
     tools = [] :: [string()],
+    manufacturer = undefined :: #organization{} | undefined,
+    authors = [] :: [#individual{}],
     properties = [] :: properties()
 }).
 

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -15,6 +15,14 @@
 
 %--- Records -------------------------------------------------------------------
 
+% Alias Author, Contact
+-record(individual, {
+    bom_ref :: bom_ref() | undefined,
+    name :: string(),
+    email :: string() | undefined,
+    phone :: string() | undefined
+}).
+
 -record(address, {
     bom_ref :: bom_ref(),
     country :: string(),
@@ -25,48 +33,21 @@
     street_address :: string()
 }).
 
--record(contact, {
-    bom_ref :: bom_ref(),
-    name :: string(),
-    email :: string(),
-    phone :: string()
- }).
-
 % Alias Manufacturer object
 -record(organization, {
     bom_ref :: bom_ref() | undefined,
     name :: string() | undefined,
     address :: #address{} | undefined,
     url :: string() | undefined,
-    contact :: #contact{} | undefined
+    contact :: #individual{} | undefined
 }).
 
-% Alias Author
--record(individual, {
-    bom_ref :: bom_ref() | undefined,
-    name :: string(),
-    email :: string() | undefined,
-    phone :: string() | undefined
-}).
-
--record(licensing, {
-    alt_id :: string(),
-    licensor :: #organization{} | #individual{},
-    licensee :: #organization{} | #individual{},
-    purchaser :: #organization{} | #individual{},
-    purchase_order :: string(),
-    licenses_types :: string(),
-    last_renewal :: calendar:datetime(),
-    expiration :: calendar:datetime()
-}).
-
-% Not adding Text or URL for now
+% Not adding Text, URL, Licensing for now
 -record(license, {
     bom_ref :: bom_ref(),
     id :: spdx_licence_id(),
     name :: string(),
-    acknowledgement :: string(), % Either "declared" or "concluded",
-    licensing :: #licensing{} | undefined,
+    acknowledgement :: declared | concluded,
     properties = [] :: properties()
 }).
 

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -24,13 +24,13 @@
 }).
 
 -record(address, {
-    bom_ref :: bom_ref(),
-    country :: string(),
-    region :: string(),
-    locality :: string(),
-    post_office_box_number :: string(),
-    postal_code :: string(),
-    street_address :: string()
+    bom_ref :: bom_ref() | undefined,
+    country :: string() | undefined,
+    region :: string() | undefined,
+    locality :: string() | undefined,
+    post_office_box_number :: string() | undefined,
+    postal_code :: string() | undefined,
+    street_address :: string() | undefined
 }).
 
 % Alias Manufacturer object
@@ -39,7 +39,7 @@
     name :: string() | undefined,
     address :: #address{} | undefined,
     url :: string() | undefined,
-    contact :: #individual{} | undefined
+    contact = [] :: [#individual{}]
 }).
 
 % Not adding Text, URL, Licensing for now

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -18,7 +18,7 @@
 % Alias Author, Contact
 -record(individual, {
     bom_ref :: bom_ref() | undefined,
-    name :: string(),
+    name :: string() | undefined,
     email :: string() | undefined,
     phone :: string() | undefined
 }).

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -34,10 +34,10 @@
 
 % Alias Manufacturer object
 -record(organization, {
-    bom_ref :: bom_ref(),
-    name :: string(),
+    bom_ref :: bom_ref() | undefined,
+    name :: string() | undefined,
     address :: #address{} | undefined,
-    url :: string(),
+    url :: string() | undefined,
     contact :: #contact{} | undefined
 }).
 
@@ -52,8 +52,8 @@
 -record(licensing, {
     alt_id :: string(),
     licensor :: #organization{} | #individual{},
-    licensee :: #organization{} | #individual{},
-    purchaser :: #organization{} | #individual{},
+    licensee :: #organization{} | #individual{},
+    purchaser :: #organization{} | #individual{},
     purchase_order :: string(),
     licenses_types :: string(),
     last_renewal :: calendar:datetime(),
@@ -89,6 +89,7 @@
     tools = [] :: [string()],
     manufacturer = undefined :: #organization{} | undefined,
     authors = [] :: [#individual{}],
+    licenses = [] :: [#license{}],
     properties = [] :: properties()
 }).
 

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -10,7 +10,7 @@
 %--- Types ---------------------------------------------------------------------
 
 -type bom_ref() :: string().
--type spdx_licence_id() :: string().
+-type spdx_licence_id() :: string(). % TODO: enumerate the valid SPDX licence IDs
 -type properties() :: [{string(), string()}].
 
 %--- Records -------------------------------------------------------------------
@@ -38,7 +38,7 @@
     bom_ref :: bom_ref() | undefined,
     name :: string() | undefined,
     address :: #address{} | undefined,
-    url :: string() | undefined,
+    url = [] :: [string()],
     contact = [] :: [#individual{}]
 }).
 

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -125,7 +125,7 @@ manufacturer(Manufacturer) ->
     #organization{name = maps:get(name, Manufacturer, undefined),
                   address = address(maps:get(address, Manufacturer, undefined)),
                   url = maps:get(url, Manufacturer, undefined),
-                  contact = maps:get(contact, Manufacturer, undefined)
+                  contact = individuals(maps:get(contact, Manufacturer, undefined))
 }.
 
 -spec address(undefined | map()) -> undefined | #address{}.
@@ -140,6 +140,18 @@ address(AddressMap) ->
         postal_code = maps:get(postal_code, AddressMap, undefined),
         street_address = maps:get(street_address, AddressMap, undefined)
     }.
+
+-spec individuals(Individuals) -> Individuals when
+    Individuals :: [string()],
+    Individuals :: [#individual{}].
+individuals(undefined) ->
+    [];
+individuals(Individuals) ->
+    lists:map(fun(Individual) ->
+        #individual{name = maps:get(name, Individual, undefined),
+                    email = maps:get(email, Individual, undefined),
+                    phone = maps:get(phone, Individual, undefined)}
+    end, Individuals).
 
 -spec authors(App) -> Authors when
     App :: proplists:proplist(),

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -124,7 +124,7 @@ manufacturer(undefined) ->
 manufacturer(Manufacturer) ->
     #organization{name = maps:get(name, Manufacturer, undefined),
                   address = address(maps:get(address, Manufacturer, undefined)),
-                  url = maps:get(url, Manufacturer, undefined),
+                  url = maps:get(url, Manufacturer, []),
                   contact = individuals(maps:get(contact, Manufacturer, undefined))
 }.
 

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -123,10 +123,23 @@ manufacturer(undefined) ->
     undefined;
 manufacturer(Manufacturer) ->
     #organization{name = maps:get(name, Manufacturer, undefined),
-                  address = maps:get(address, Manufacturer, undefined),
+                  address = address(maps:get(address, Manufacturer, undefined)),
                   url = maps:get(url, Manufacturer, undefined),
                   contact = maps:get(contact, Manufacturer, undefined)
 }.
+
+-spec address(undefined | map()) -> undefined | #address{}.
+address(undefined) ->
+    undefined;
+address(AddressMap) ->
+    #address{
+        country = maps:get(country, AddressMap, undefined),
+        region = maps:get(region, AddressMap, undefined),
+        locality = maps:get(locality, AddressMap, undefined),
+        post_office_box_number = maps:get(post_office_box_number, AddressMap, undefined),
+        postal_code = maps:get(postal_code, AddressMap, undefined),
+        street_address = maps:get(street_address, AddressMap, undefined)
+    }.
 
 -spec authors(App) -> Authors when
     App :: proplists:proplist(),

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -40,7 +40,7 @@ component_to_json(C) ->
     prune_content(#{
         type => bin(C#component.type),
         'bom-ref' => bin(C#component.bom_ref),
-        authors => authors_to_json(C#component.authors),
+        authors => individuals_to_json(C#component.authors),
         name => bin(C#component.name),
         version => bin(C#component.version),
         description => bin(C#component.description),
@@ -53,13 +53,15 @@ component_to_json(C) ->
 prune_content(Component) ->
     maps:filter(fun(_, Value) -> Value =/= undefined end, Component).
 
--spec authors_to_json([#individual{}]) -> [#{name => binary()}].
-authors_to_json(Authors) ->
-    [author_to_json(A) || A <- Authors].
+-spec individuals_to_json([#individual{}]) -> [#{name => binary()}].
+individuals_to_json(Individuals) ->
+    [individual_to_json(I) || I <- Individuals].
 
--spec author_to_json(#individual{}) -> #{name => binary()}.
-author_to_json(#individual{name = Name}) ->
-    #{name => bin(Name)}.
+-spec individual_to_json(#individual{}) -> #{name => binary()}.
+individual_to_json(Individual) ->
+    prune_content(#{name => bin(Individual#individual.name),
+                    email => bin(Individual#individual.email),
+                    phone => bin(Individual#individual.phone)}).
 
 -spec metadata_to_json(#metadata{}) -> map().
 metadata_to_json(Metadata) ->
@@ -68,7 +70,7 @@ metadata_to_json(Metadata) ->
         tools => [#{name => bin(T)} || T <- Metadata#metadata.tools],
         component => component_to_json(Metadata#metadata.component),
         manufacturer => manufacturer_to_json(Metadata#metadata.manufacturer),
-        authors => authors_to_json(Metadata#metadata.authors),
+        authors => individuals_to_json(Metadata#metadata.authors),
         licenses => licenses_to_json(Metadata#metadata.licenses)
     }).
 
@@ -80,7 +82,7 @@ manufacturer_to_json(Manufacturer) ->
         name => bin(Manufacturer#organization.name),
         address => address_to_json(Manufacturer#organization.address),
         url => bin(Manufacturer#organization.url),
-        contact => bin(Manufacturer#organization.contact)
+        contact => individuals_to_json(Manufacturer#organization.contact)
     }).
 
 -spec address_to_json(#address{}) -> map().

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -97,7 +97,7 @@ address_to_json(Address) ->
     }).
 
 -spec urls_to_json([string()]) -> [string()].
-urls_to_json(undefined) ->
+urls_to_json([]) ->
     undefined;
 urls_to_json(Urls) ->
     [bin(Url) || Url <- Urls].

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -31,12 +31,7 @@ sbom_to_json(#sbom{metadata = Metadata} = SBoM) ->
         specVersion => ?SPEC_VERSION,
         serialNumber => bin(SBoM#sbom.serial),
         version => SBoM#sbom.version,
-        metadata => #{
-            timestamp => bin(Metadata#metadata.timestamp),
-            tools => [#{name => bin(T)} || T <- Metadata#metadata.tools],
-            component => component_to_json(Metadata#metadata.component),
-            authors => authors_to_json(Metadata#metadata.authors)
-        },
+        metadata => metadata_to_json(Metadata),
         components => [component_to_json(C) || C <- SBoM#sbom.components],
         dependencies => [dependency_to_json(D) || D <- SBoM#sbom.dependencies]
     }.
@@ -65,6 +60,28 @@ authors_to_json(Authors) ->
 -spec author_to_json(#individual{}) -> #{name => binary()}.
 author_to_json(#individual{name = Name}) ->
     #{name => bin(Name)}.
+
+-spec metadata_to_json(#metadata{}) -> map().
+metadata_to_json(Metadata) ->
+    prune_content(#{
+        timestamp => bin(Metadata#metadata.timestamp),
+        tools => [#{name => bin(T)} || T <- Metadata#metadata.tools],
+        component => component_to_json(Metadata#metadata.component),
+        manufacturer => manufacturer_to_json(Metadata#metadata.manufacturer),
+        authors => authors_to_json(Metadata#metadata.authors),
+        licenses => licenses_to_json(Metadata#metadata.licenses)
+    }).
+
+-spec manufacturer_to_json(#organization{} | undefined) -> map() | undefined.
+manufacturer_to_json(undefined) ->
+    undefined;
+manufacturer_to_json(Manufacturer) ->
+    prune_content(#{
+        name => bin(Manufacturer#organization.name),
+        address => bin(Manufacturer#organization.address),
+        url => bin(Manufacturer#organization.url),
+        contact => bin(Manufacturer#organization.contact)
+    }).
 
 hashes_to_json(Hashes) ->
     [hash_to_json(H) || H <- Hashes].

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -34,7 +34,8 @@ sbom_to_json(#sbom{metadata = Metadata} = SBoM) ->
         metadata => #{
             timestamp => bin(Metadata#metadata.timestamp),
             tools => [#{name => bin(T)} || T <- Metadata#metadata.tools],
-            component => component_to_json(Metadata#metadata.component)
+            component => component_to_json(Metadata#metadata.component),
+            authors => authors_to_json(Metadata#metadata.authors)
         },
         components => [component_to_json(C) || C <- SBoM#sbom.components],
         dependencies => [dependency_to_json(D) || D <- SBoM#sbom.dependencies]
@@ -57,10 +58,12 @@ component_to_json(C) ->
 prune_content(Component) ->
     maps:filter(fun(_, Value) -> Value =/= undefined end, Component).
 
+-spec authors_to_json([#individual{}]) -> [#{name => binary()}].
 authors_to_json(Authors) ->
     [author_to_json(A) || A <- Authors].
 
-author_to_json(#{name := Name}) ->
+-spec author_to_json(#individual{}) -> #{name => binary()}.
+author_to_json(#individual{name = Name}) ->
     #{name => bin(Name)}.
 
 hashes_to_json(Hashes) ->

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -78,9 +78,20 @@ manufacturer_to_json(undefined) ->
 manufacturer_to_json(Manufacturer) ->
     prune_content(#{
         name => bin(Manufacturer#organization.name),
-        address => bin(Manufacturer#organization.address),
+        address => address_to_json(Manufacturer#organization.address),
         url => bin(Manufacturer#organization.url),
         contact => bin(Manufacturer#organization.contact)
+    }).
+
+-spec address_to_json(#address{}) -> map().
+address_to_json(Address) ->
+    prune_content(#{
+        country => bin(Address#address.country),
+        region => bin(Address#address.region),
+        locality => bin(Address#address.locality),
+        post_office_box_number => bin(Address#address.post_office_box_number),
+        postal_code => bin(Address#address.postal_code),
+        street_address => bin(Address#address.street_address)
     }).
 
 hashes_to_json(Hashes) ->

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -81,7 +81,7 @@ manufacturer_to_json(Manufacturer) ->
     prune_content(#{
         name => bin(Manufacturer#organization.name),
         address => address_to_json(Manufacturer#organization.address),
-        url => bin(Manufacturer#organization.url),
+        url => urls_to_json(Manufacturer#organization.url),
         contact => individuals_to_json(Manufacturer#organization.contact)
     }).
 
@@ -95,6 +95,12 @@ address_to_json(Address) ->
         postal_code => bin(Address#address.postal_code),
         street_address => bin(Address#address.street_address)
     }).
+
+-spec urls_to_json([string()]) -> [string()].
+urls_to_json(undefined) ->
+    undefined;
+urls_to_json(Urls) ->
+    [bin(Url) || Url <- Urls].
 
 hashes_to_json(Hashes) ->
     [hash_to_json(H) || H <- Hashes].

--- a/test/basic_app/rebar.config
+++ b/test/basic_app/rebar.config
@@ -3,7 +3,13 @@
 {rebar3_sbom, [
     {sbom_manufacturer, #{
         name => "The comunity of the Ring",
-        address => "Bag End, Hobbiton, Shire"
+        address => #{
+                country => "Middle-earth",
+                region => "Shire",
+                locality => "Hobbiton",
+                postal_code => "12345",
+                street_address => "Bag End, Hobbiton, Shire"
+            }
     }},
     {sbom_licenses, ["BSD-3-Clause"]}
 ]}.

--- a/test/basic_app/rebar.config
+++ b/test/basic_app/rebar.config
@@ -10,6 +10,7 @@
                 postal_code => "12345",
                 street_address => "Bag End, Hobbiton, Shire"
             },
+        url => ["https://example.com", "https://another-example.com"],
         contact => [
             #{name => "Frodo Baggins"},
             #{name => "Gandalf the Grey",

--- a/test/basic_app/rebar.config
+++ b/test/basic_app/rebar.config
@@ -9,7 +9,12 @@
                 locality => "Hobbiton",
                 postal_code => "12345",
                 street_address => "Bag End, Hobbiton, Shire"
-            }
+            },
+        contact => [
+            #{name => "Frodo Baggins"},
+            #{name => "Gandalf the Grey",
+              phone => "1234567890"}
+        ]
     }},
     {sbom_licenses, ["BSD-3-Clause"]}
 ]}.

--- a/test/basic_app/rebar.config
+++ b/test/basic_app/rebar.config
@@ -1,4 +1,13 @@
 {erl_opts, [debug_info]}.
+
+{rebar3_sbom, [
+    {sbom_manufacturer, #{
+        name => "The comunity of the Ring",
+        address => "Bag End, Hobbiton, Shire"
+    }},
+    {sbom_licenses, ["BSD-3-Clause"]}
+]}.
+
 {deps, [
     meck,
     grisp

--- a/test/basic_app/src/basic_app.app.src
+++ b/test/basic_app/src/basic_app.app.src
@@ -10,5 +10,6 @@
     {env, []},
     {modules, []},
     {licenses, ["Apache-2.0"]},
-    {links, []}
+    {links, []},
+    {maintainers, ["John Doe"]}
  ]}.

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -264,7 +264,14 @@ component_test(Config) ->
 manufacturer_test(Config) ->
     #{<<"manufacturer">> := Manufacturer} = ?config(metadata, Config),
     ?assertMatch(#{<<"name">> := <<"The comunity of the Ring">>}, Manufacturer),
-    ?assertMatch(#{<<"address">> := <<"Bag End, Hobbiton, Shire">>}, Manufacturer),
+    ?assertMatch(#{<<"address">> := _}, Manufacturer),
+    #{<<"address">> := Address} = Manufacturer,
+    ?assertMatch(#{<<"country">> := <<"Middle-earth">>,
+                   <<"region">> := <<"Shire">>,
+                   <<"locality">> := <<"Hobbiton">>,
+                   <<"postal_code">> := <<"12345">>,
+                   <<"street_address">> := <<"Bag End, Hobbiton, Shire">>}, Address),
+    ?assertNotMatch(#{<<"post_office_box_number">> := _}, Address),
     ?assertNotMatch(#{<<"bom-ref">> := _}, Manufacturer),
     ?assertNotMatch(#{<<"url">> := _}, Manufacturer),
     ?assertNotMatch(#{<<"contact">> := _}, Manufacturer).

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -271,10 +271,14 @@ manufacturer_test(Config) ->
                    <<"locality">> := <<"Hobbiton">>,
                    <<"postal_code">> := <<"12345">>,
                    <<"street_address">> := <<"Bag End, Hobbiton, Shire">>}, Address),
+    ?assertMatch(#{<<"contact">> := [_ | _]}, Manufacturer),
+    #{<<"contact">> := [Contact1, Contact2]} = Manufacturer,
+    ?assertEqual(#{<<"name">> => <<"Frodo Baggins">>}, Contact1),
+    ?assertEqual(#{<<"name">> => <<"Gandalf the Grey">>,
+                   <<"phone">> => <<"1234567890">>}, Contact2),
     ?assertNotMatch(#{<<"post_office_box_number">> := _}, Address),
     ?assertNotMatch(#{<<"bom-ref">> := _}, Manufacturer),
-    ?assertNotMatch(#{<<"url">> := _}, Manufacturer),
-    ?assertNotMatch(#{<<"contact">> := _}, Manufacturer).
+    ?assertNotMatch(#{<<"url">> := _}, Manufacturer).
 
 %--- basic_app_with_sbom group ---
 serial_number_change_test(Config) ->


### PR DESCRIPTION
This PR adds the following missing metadata properties:

- `metadata.authors`: The authors of the SBoM
- `metadata.manufacturer`: The manufacturer of the SBoM
- `metadata.licenses`: The licenses of the SBoM

The PR also adds these records:

- `#individual{}`: Represents a person. This groups the objects "Individual", "Author", "Contact", etc., from the CycloneDX specifications.
- `#address{}`: Represents any address. Used in `#organization{}`.
- `#organization{}`: Represents any type of company. This groups the objects "Organization", "Manufacturer", "Supplier", "Licensee", etc., from the CycloneDX specifications.
- `#license{}`: Represents any license.

## Information Filling Strategies

For each property, we decided how to retrieve the information and populate it inside the SBoM.

The `README.md` file has also been updated to explain how to use these options.

### metadata.authors

The information is retrieved in 3 steps:

1. The user specifies their information using the `--author` option. For example: `rebar3 sbom --author "John Doe"`.
2. If no option is specified, the plugin checks if the `GITHUB_ACTOR` variable is defined. If it is, that value is used.
3. Otherwise, the plugin defaults to the same value as `metadata.component.authors`.

Using configuration files for this was not an option because it would require every SBoM author to keep a local version of the config file, which is inconvenient.

### metadata.manufacturer

The plugin checks if the value is defined in the config file. If no value is specified, `metadata.manufacturer` is omitted.

### metadata.licenses

The plugin checks if the value is configured in the config file. Otherwise, it defaults to the same value as `metadata.component.licenses`.

## Miscellaneous

- The usage of "SBoM" and "BoM" in the repo was inconsistent. I fixed this wherever I found inconsistencies.
- I also removed trailing whitespaces and stray characters on a few lines.
- New tests have been created to reflect all the changes of this PR.
- In the tests, I commented out the test `tools_test`. The component `metadata.tools` is incomplete and needs to be fixed in a future PR.