### PR TITLE
External references

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,37 @@ CPE Generation
 
 The plugin automatically generates a CPE (Common Platform Enumeration) identifier for the main component (`metadata.component`) using the GitHub link from your project's `.app.src` file. If no GitHub link is present, the CPE field is omitted from the SBoM.
 
-To ensure CPE generation, add a GitHub link to your `.app.src` file:
+To ensure CPE generation, add a GitHub link to your `.app.src` file. For example:
+
 
     {application, my_app, [
         ...
         {links, [
             {"GitHub", "https://github.com/your-org/my_app"}
+        ]}
+    ]}.
+
+External References
+-------------------
+
+The plugin supports external references for components, which are automatically extracted from the `links` field in your `.app.src` file or from Hex metadata for dependencies.
+
+All standard CycloneDX external reference types are supported. Additionally, for convenience, the plugin supports common field names used by the Erlang/Elixir community, which are automatically mapped to their CycloneDX equivalents:
+
+- `"Homepage"` → `"website"`
+- `"Changelog"` → `"release-notes"`
+- `"Sponsor"` → `"support"`
+- `"Issues"` → `"issue-tracker"`
+
+You can use either the standard CycloneDX type names or the community convention names in your `.app.src` file:
+
+    {application, my_app, [
+        ...
+        {links, [
+            {"GitHub", "https://github.com/your-org/my_app"},
+            {"Homepage", "https://example.com"},
+            {"Changelog", "https://github.com/example/my_app/releases"},
+            {"Issues", "https://github.com/example/my_app/issues"},
+            {"Sponsor", "<your sponsor link>"}
         ]}
     ]}.

--- a/README.md
+++ b/README.md
@@ -106,17 +106,20 @@ The plugin supports external references for components, which are automatically 
 
 All standard CycloneDX external reference types are supported. Additionally, for convenience, the plugin supports common field names used by the Erlang/Elixir community, which are automatically mapped to their CycloneDX equivalents:
 
+- `"GitHub"` → `"vcs"`
 - `"Homepage"` → `"website"`
 - `"Changelog"` → `"release-notes"`
 - `"Sponsor"` → `"support"`
 - `"Issues"` → `"issue-tracker"`
+
+**Note:** The plugin treats the names (i.e., `"Homepage"`, `"GitHub"`, etc.) in the `links` field as case-insensitive, so `"homepage"` and `"HOMEPAGE"` will also map to `"website"`, for example.
 
 You can use either the standard CycloneDX type names or the community convention names in your `.app.src` file:
 
     {application, my_app, [
         ...
         {links, [
-            {"GitHub", "https://github.com/your-org/my_app"},
+            {"GitHub", "https://github.com/example/my_app"},
             {"Homepage", "https://example.com"},
             {"Changelog", "https://github.com/example/my_app/releases"},
             {"Issues", "https://github.com/example/my_app/issues"},

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ All standard CycloneDX external reference types are supported. Additionally, for
 - `"GitHub"` → `"vcs"`
 - `"Homepage"` → `"website"`
 - `"Changelog"` → `"release-notes"`
-- `"Sponsor"` → `"support"`
 - `"Issues"` → `"issue-tracker"`
+- `"Documentation"` → `"documentation"`
 
 **Note:** The plugin treats the names (i.e., `"Homepage"`, `"GitHub"`, etc.) in the `links` field as case-insensitive, so `"homepage"` and `"HOMEPAGE"` will also map to `"website"`, for example.
 
@@ -123,6 +123,6 @@ You can use either the standard CycloneDX type names or the community convention
             {"Homepage", "https://example.com"},
             {"Changelog", "https://github.com/example/my_app/releases"},
             {"Issues", "https://github.com/example/my_app/issues"},
-            {"Sponsor", "<your sponsor link>"}
+            {"Documentation", "https://example.com/documentation"}
         ]}
     ]}.

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -17,6 +17,11 @@
 
 %--- Records -------------------------------------------------------------------
 
+-record(external_reference, {
+    type :: string(),
+    url :: string()
+}).
+
 % Alias Author, Contact
 -record(individual, {
     bom_ref :: bom_ref() | undefined,
@@ -63,7 +68,7 @@
     scope :: scope(),
     hashes = [] :: [#{alg := string(), hash := string()}],
     licenses = [] :: [#{name := string()} | #{id := string()}],
-    externalReferences = [] :: [#{type := string(), url := string()}],
+    externalReferences = [] :: [#external_reference{}],
     cpe :: string() | undefined,
     purl :: string()
 }).

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -100,7 +100,8 @@ component_field(external_references = Field, RawComponent) ->
         [] ->
             [];
         References ->
-            [#{type => Type, url => Url} || {Type, Url} <- References]
+            [#external_reference{type = Type, url = Url} ||
+             {Type, Url} <- maps:to_list(References)]
     end;
 component_field(Field, RawComponent) ->
     case proplists:get_value(Field, RawComponent) of

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -113,7 +113,7 @@ hash_to_json(#{alg := Alg, hash := Hash}) ->
 external_references_to_json(ExternalReferences) ->
     [external_reference_to_json(R) || R <- ExternalReferences].
 
-external_reference_to_json(#{type := Type, url := Url}) ->
+external_reference_to_json(#external_reference{type = Type, url = Url}) ->
     #{type => bin(Type), url => bin(Url)}.
 
 licenses_to_json(Licenses) ->
@@ -201,7 +201,7 @@ json_to_external_references(ExternalReferences) ->
     [json_to_external_reference(R) || R <- ExternalReferences].
 
 json_to_external_reference(#{<<"type">> := Type, <<"url">> := Url}) ->
-    #{type => str(Type), url => str(Url)}.
+    #external_reference{type = str(Type), url = str(Url)}.
 
 str(undefined) ->
     undefined;

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -152,7 +152,7 @@ find_references(Links) ->
                         false ->
                             Acc
                     end;
-                MappedType when LowerType =:= "changelog" andalso
+                _ when LowerType =:= "changelog" andalso
                                 is_map_key("release-note", Acc) ->
                     % changelog is a fallback for release-note.
                     % We don't overwrite the release-note if it already exists.

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -134,20 +134,22 @@ get_github_link(HexMetadata, _) ->
     proplists:get_value(<<"GitHub">>, Links, undefined).
 
 custom_mapping() ->
-    #{"Homepage" => "website",
-      "Changelog" => "release-notes",
-      "Sponsor" => "support",
-      "Issues" => "issue-tracker"}.
+    #{"github" => "vcs",
+      "homepage" => "website",
+      "changelog" => "release-notes",
+      "sponsor" => "support",
+      "issues" => "issue-tracker"}.
 
 find_references(Links) ->
     CustomMapping = custom_mapping(),
     lists:foldl(
         fun({Type, Url}, Acc) ->
-            case maps:get(Type, CustomMapping, undefined) of
+            LowerType = string:to_lower(Type),
+            case maps:get(LowerType, CustomMapping, undefined) of
                 undefined ->
-                    case lists:member(Type, valid_external_reference_types()) of
+                    case lists:member(LowerType, valid_external_reference_types()) of
                         true ->
-                            Acc#{Type => Url};
+                            Acc#{LowerType => Url};
                         false ->
                             Acc
                     end;
@@ -167,7 +169,8 @@ valid_external_reference_types() ->
      "pentest-report", "static-analysis-report", "dynamic-analysis-report",
      "runtime-analysis-report", "component-analysis-report", "maturity-report",
      "certification-report", "codified-infrastructure", "quality-metrics",
-     "poam", "electronic-signature", "digital-signature", "rfc-9116", "other"].
+     "poam", "electronic-signature", "digital-signature", "rfc-9116",
+     "patent", "patent-family", "patent-assertion", "citation", "other"].
 
 dep_info(_Name, _Version, {pkg, Name, Version, Sha256}, Common) ->
     [

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -4,6 +4,13 @@
 
 -include("rebar3_sbom.hrl").
 
+%--- Macros --------------------------------------------------------------------
+-define(CUSTOM_MAPPING, #{"github" => "vcs",
+                          "homepage" => "website",
+                          "changelog" => "release-notes",
+                          "sponsor" => "support",
+                          "issues" => "issue-tracker"}).
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -133,19 +140,11 @@ get_github_link(HexMetadata, _) ->
     Links = proplists:get_value(<<"links">>, HexMetadata, []),
     proplists:get_value(<<"GitHub">>, Links, undefined).
 
-custom_mapping() ->
-    #{"github" => "vcs",
-      "homepage" => "website",
-      "changelog" => "release-notes",
-      "sponsor" => "support",
-      "issues" => "issue-tracker"}.
-
 find_references(Links) ->
-    CustomMapping = custom_mapping(),
     lists:foldl(
         fun({Type, Url}, Acc) ->
             LowerType = string:to_lower(Type),
-            case maps:get(LowerType, CustomMapping, undefined) of
+            case maps:get(LowerType, ?CUSTOM_MAPPING, undefined) of
                 undefined ->
                     case lists:member(LowerType, valid_external_reference_types()) of
                         true ->

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -7,8 +7,8 @@
 %--- Macros --------------------------------------------------------------------
 -define(CUSTOM_MAPPING, #{"github" => "vcs",
                           "homepage" => "website",
+                          "releases" => "release-notes",
                           "changelog" => "release-notes",
-                          "sponsor" => "support",
                           "issues" => "issue-tracker"}).
 
 %% ===================================================================
@@ -152,6 +152,11 @@ find_references(Links) ->
                         false ->
                             Acc
                     end;
+                MappedType when LowerType =:= "changelog" andalso
+                                is_map_key("release-note", Acc) ->
+                    % changelog is a fallback for release-note.
+                    % We don't overwrite the release-note if it already exists.
+                    Acc;
                 MappedType ->
                     Acc#{MappedType => Url}
             end

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -97,7 +97,7 @@ license_to_xml(#{name := Name}) ->
 license_to_xml(#{id := Id}) ->
     {license, [{id, [Id]}]}.
 
-external_reference_to_xml(#{type := Type, url := Url}) ->
+external_reference_to_xml(#external_reference{type = Type, url = Url}) ->
     {reference, [{type, Type}], [{url, [Url]}]}.
 
 dependency_to_xml(Dependency) ->
@@ -157,7 +157,7 @@ xml_to_hash(HashElement) ->
 xml_to_external_reference(ExternalReferenceElement) ->
     [#xmlAttribute{value = Type}] = xpath("/reference/@type", ExternalReferenceElement),
     [#xmlText{value = Url}] = xpath("/reference/url/text()", ExternalReferenceElement),
-    #{type => Type, url => Url}.
+    #external_reference{type = Type, url = Url}.
 
 xml_to_license(LicenseElement) ->
     case xpath("/license/id/text()", LicenseElement) of

--- a/test/basic_app/src/basic_app.app.src
+++ b/test/basic_app/src/basic_app.app.src
@@ -11,7 +11,11 @@
     {modules, []},
     {licenses, ["Apache-2.0"]},
     {links, [
-        {"GitHub", "https://github.com/example-org/basic_app"}
+        {"GitHub", "https://github.com/example-org/basic_app"},
+        {"Homepage", "https://example.com"},
+        {"Changelog", "https://example.com/changelog"},
+        {"Sponsor", "https://example.com/sponsor"},
+        {"Issues", "https://example.com/issues"}
     ]},
     {maintainers, ["John Doe"]}
  ]}.

--- a/test/basic_app/src/basic_app.app.src
+++ b/test/basic_app/src/basic_app.app.src
@@ -14,6 +14,7 @@
         {"GitHub", "https://github.com/example-org/basic_app"},
         {"Homepage", "https://example.com"},
         {"Changelog", "https://example.com/changelog"},
+        {"Releases", "https://example.com/releases"},
         {"Sponsor", "https://example.com/sponsor"},
         {"Issues", "https://example.com/issues"},
         {"documentation", "https://example.com/documentation"}

--- a/test/basic_app/src/basic_app.app.src
+++ b/test/basic_app/src/basic_app.app.src
@@ -15,7 +15,8 @@
         {"Homepage", "https://example.com"},
         {"Changelog", "https://example.com/changelog"},
         {"Sponsor", "https://example.com/sponsor"},
-        {"Issues", "https://example.com/issues"}
+        {"Issues", "https://example.com/issues"},
+        {"documentation", "https://example.com/documentation"}
     ]},
     {maintainers, ["John Doe"]}
  ]}.

--- a/test/local_app/src/local_app.app.src
+++ b/test/local_app/src/local_app.app.src
@@ -10,5 +10,7 @@
     {env, []},
     {modules, []},
     {licenses, ["Apache-2.0"]},
-    {links, []}
+    {links, [
+        {"Changelog", "https://example.com/changelog"}
+    ]}
  ]}.

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -288,6 +288,14 @@ metadata_component_hashes_test(Config) ->
     ?assertMatch(#{<<"alg">> := <<"SHA-256">>,
                    <<"content">> := ExpectedHash}, Hash).
 
+% TODO: Use it after rebase
+external_references_fallback_test(Config) ->
+    SBoMJSON = ?config(sbom_json, Config),
+    #{<<"metadata">> := #{<<"component">> := Component}} = SBoMJSON,
+    #{<<"externalReferences">> := ExternalReferences} = Component,
+    ?assertNotMatch([#{<<"type">> := <<"release-notes">>, <<"url">> := <<"https://example.com/releases">>}], ExternalReferences),
+    ?assertMatch([#{<<"type">> := <<"release-notes">>, <<"url">> := <<"https://example.com/changelog">>}], ExternalReferences).
+
 %--- metadata group ---
 timestamp_test(Config) ->
     SBoMJSON = ?config(sbom_json, Config),
@@ -362,15 +370,14 @@ component_test(Config) ->
     ExpectedExternalReferences = [
         #{<<"type">> => <<"vcs">>, <<"url">> => <<"https://github.com/example-org/basic_app">>},
         #{<<"type">> => <<"website">>, <<"url">> => <<"https://example.com">>},
-        #{<<"type">> => <<"release-notes">>, <<"url">> => <<"https://example.com/changelog">>},
-        #{<<"type">> => <<"support">>, <<"url">> => <<"https://example.com/sponsor">>},
+        #{<<"type">> => <<"release-notes">>, <<"url">> => <<"https://example.com/releases">>},
         #{<<"type">> => <<"issue-tracker">>, <<"url">> => <<"https://example.com/issues">>},
         #{<<"type">> => <<"documentation">>, <<"url">> => <<"https://example.com/documentation">>}],
     lists:foreach(fun(ExpectedExternalReference) ->
         ?assert(lists:member(ExpectedExternalReference, ExternalReferences),
                 ExpectedExternalReference)
     end, ExpectedExternalReferences),
-    ?assertEqual(6, length(ExternalReferences)).
+    ?assertEqual(5, length(ExternalReferences)).
 
 manufacturer_test(Config) ->
     #{<<"manufacturer">> := Manufacturer} = ?config(metadata, Config),


### PR DESCRIPTION
This PR enhances external references handling in SBoM generation.

**Changes:**

- Use `#external_reference{}` record instead of maps for consistency

- Add custom mapping using community conventions (case-insensitive):
  - `"Github"` → `"vcs"`
  - `"Homepage"` → `"website"`
  - `"Changelog"` → `"release-notes"`
  - `"Sponsor"` → `"support"`
  - `"Issues"` → `"issue-tracker"`

- Add missing external reference types: `"patent"`, `"patent-family"`, `"patent-assertion"`, `"citation"`

- Add README section documenting the custom mapping

- Add test cases

**Note:** Dependency external references testing is limited since we don't control their metadata. Should we go further in testing or do you think that the current tests are sufficient?