### PR TITLE
Support for local and git dependencies

### DIFF
--- a/src/rebar3_sbom_cpe.erl
+++ b/src/rebar3_sbom_cpe.erl
@@ -1,6 +1,6 @@
 -module(rebar3_sbom_cpe).
 
--export([hex/3]).
+-export([cpe/3]).
 
 % Includes
 -include("rebar3_sbom.hrl").
@@ -25,60 +25,62 @@
 
 %--- API -----------------------------------------------------------------------
 
--spec hex(Name, Version, Url) -> CPE when
+-spec cpe(Name, Version, Url) -> CPE when
     Name :: bitstring(),
     Version :: bitstring(),
     Url :: bitstring() | undefined,
     CPE :: bitstring().
-hex(Name, undefined, Url) ->
-    hex(Name, <<"*">>, Url);
-hex(<<"hex_core">>, Version, _) ->
+cpe(Name, undefined, Url) ->
+    cpe(Name, <<"*">>, Url);
+cpe(<<"hex_core">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":hex:hex_core:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"plug">>, Version, _) ->
+cpe(<<"plug">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":elixir-plug:plug:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"phoenix">>, Version, _) ->
+cpe(<<"phoenix">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":phoenixframework:phoenix:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"coherence">>, Version, _) ->
+cpe(<<"coherence">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":coherence_project:coherence:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"xain">>, Version, _) ->
+cpe(<<"xain">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":emetrotel:xain:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"sweet_xml">>, Version, _) ->
+cpe(<<"sweet_xml">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":kbrw:sweet_xml:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"erlang/otp">>, Version, _) ->
+cpe(<<"erlang/otp">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":erlang:erlang\/otp:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"rebar3">>, Version, _) ->
+cpe(<<"rebar3">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":erlang:rebar3:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(<<"elixir">>, Version, _) ->
+cpe(<<"elixir">>, Version, _) ->
     <<?CPE_PREFIX/binary, ":", ?CPE_PART_APPLICATION/binary,
       ":elixir-lang:elixir:", Version/bitstring, ?CPE_POSTFIX/binary>>;
-hex(_Name, _Version, undefined) ->
+cpe(_Name, _Version, undefined) ->
     undefined;
-hex(Name, Version, Url) ->
+cpe(Name, Version, Url) ->
     Organization = github_url(Url),
-    cpe(Organization, Name, Version).
+    build_cpe(Organization, Name, Version).
 
 %--- Private -------------------------------------------------------------------
 
 -spec github_url(Url) -> Organization when
     Url :: bitstring(),
     Organization :: bitstring().
-github_url(Url) ->
-    <<"https://github.com/", Rest/bitstring>> = Url,
+github_url(<<"https://github.com/", Rest/bitstring>>) ->
+    [Organization | _] = string:split(Rest, "/"),
+    Organization;
+github_url(<<"git@github.com:", Rest/bitstring>>) ->
     [Organization | _] = string:split(Rest, "/"),
     Organization.
 
--spec cpe(Organization, Name, Version) -> CPE when
+-spec build_cpe(Organization, Name, Version) -> CPE when
     Organization :: bitstring(),
     Name :: bitstring(),
     Version :: bitstring(),
     CPE :: bitstring().
-cpe(Organization, Name, Version) ->
+build_cpe(Organization, Name, Version) ->
     <<?CPE_PREFIX/binary, ":a:", Organization/binary, ":", Name/binary, ":", Version/bitstring, ?CPE_POSTFIX/binary>>.

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -210,6 +210,13 @@ dep_info(Name, DepVersion, {git, Git, GitRef}, Common) ->
 dep_info(Name, Version, {git_subdir, Git, Ref, _Dir}, Common) ->
     dep_info(Name, Version, {git, Git, Ref}, Common);
 
+dep_info(Name, Version, checkout, Common) ->
+    [
+     {name, Name},
+     {version, Version},
+     {purl, rebar3_sbom_purl:local(Name, Version)}
+    | Common ];
+
 dep_info(Name, Version, root_app, Common) ->
     Purl = rebar3_sbom_purl:hex(Name, Version),
     [

--- a/src/rebar3_sbom_purl.erl
+++ b/src/rebar3_sbom_purl.erl
@@ -2,7 +2,7 @@
 
 % https://github.com/package-url/purl-spec
 
--export([hex/2, git/3, github/2, bitbucket/2]).
+-export([hex/2, git/3, github/2, bitbucket/2, local/2]).
 
 hex(Name, Version) ->
     purl(["hex", string:lowercase(Name)], Version).
@@ -42,6 +42,9 @@ github(Repo, Ref) ->
 bitbucket(Repo, Ref) ->
     [Organization, Name | _] = string:split(Repo, "/"),
     purl(["bitbucket", string:lowercase(Organization), string:lowercase(Name)], Ref).
+
+local(Name, Version) ->
+    purl(["generic", string:lowercase(Name)], Version).
 
 purl(PathSegments, Version) ->
     Path = lists:join("/", [escape(Segment) || Segment <- PathSegments]),

--- a/src/rebar3_sbom_purl.erl
+++ b/src/rebar3_sbom_purl.erl
@@ -2,7 +2,7 @@
 
 % https://github.com/package-url/purl-spec
 
--export([hex/2, git/3, github/2, bitbucket/2, local/2]).
+-export([hex/2, git/3, github/2, bitbucket/2, local_otp_app/2, local/2]).
 
 hex(Name, Version) ->
     purl(["hex", string:lowercase(Name)], Version).
@@ -42,6 +42,9 @@ github(Repo, Ref) ->
 bitbucket(Repo, Ref) ->
     [Organization, Name | _] = string:split(Repo, "/"),
     purl(["bitbucket", string:lowercase(Organization), string:lowercase(Name)], Ref).
+
+local_otp_app(Name, Version) ->
+    purl(["otp", string:lowercase(Name)], Version).
 
 local(Name, Version) ->
     purl(["generic", string:lowercase(Name)], Version).

--- a/test/local_app/_checkouts/checkout_app/rebar.config
+++ b/test/local_app/_checkouts/checkout_app/rebar.config
@@ -1,13 +1,7 @@
 {erl_opts, [debug_info]}.
-
-{rebar3_sbom, [
-]}.
-
-{deps, [
-    checkout_app
-]}.
+{deps, []}.
 
 {shell, [
     %% {config, "config/sys.config"},
-    {apps, [local_app]}
+    {apps, [checkout_app]}
 ]}.

--- a/test/local_app/_checkouts/checkout_app/src/checkout_app.app.src
+++ b/test/local_app/_checkouts/checkout_app/src/checkout_app.app.src
@@ -1,0 +1,14 @@
+{application, checkout_app, [
+    {description, "An OTP application"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {checkout_app_app, []}},
+    {applications, [
+        kernel,
+        stdlib
+    ]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]},
+    {links, []}
+ ]}.

--- a/test/local_app/_checkouts/checkout_app/src/checkout_app_app.erl
+++ b/test/local_app/_checkouts/checkout_app/src/checkout_app_app.erl
@@ -1,0 +1,18 @@
+%%%-------------------------------------------------------------------
+%% @doc checkout_app public API
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(checkout_app_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    checkout_app_sup:start_link().
+
+stop(_State) ->
+    ok.
+
+%% internal functions

--- a/test/local_app/_checkouts/checkout_app/src/checkout_app_sup.erl
+++ b/test/local_app/_checkouts/checkout_app/src/checkout_app_sup.erl
@@ -1,0 +1,37 @@
+%%%-------------------------------------------------------------------
+%% @doc checkout_app top level supervisor.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(checkout_app_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%% sup_flags() = #{strategy => strategy(),         % optional
+%%                 intensity => non_neg_integer(), % optional
+%%                 period => pos_integer()}        % optional
+%% child_spec() = #{id => child_id(),       % mandatory
+%%                  start => mfargs(),      % mandatory
+%%                  restart => restart(),   % optional
+%%                  shutdown => shutdown(), % optional
+%%                  type => worker(),       % optional
+%%                  modules => modules()}   % optional
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_all,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.
+
+%% internal functions

--- a/test/rebar3_sbom_cpe_SUITE.erl
+++ b/test/rebar3_sbom_cpe_SUITE.erl
@@ -51,65 +51,65 @@ end_per_testcase(_, _Config) ->
 %--- Test cases ----------------------------------------------------------------
 
 hex_core_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"hex_core">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"hex_core">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:hex:hex_core:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"hex_core">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"hex_core">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:hex:hex_core:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 plug_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"plug">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"plug">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-plug:plug:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"plug">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"plug">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-plug:plug:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 phoenix_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"phoenix">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"phoenix">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:phoenixframework:phoenix:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"phoenix">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"phoenix">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:phoenixframework:phoenix:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 coherence_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"coherence">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"coherence">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:coherence_project:coherence:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"coherence">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"coherence">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:coherence_project:coherence:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 xain_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"xain">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"xain">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:emetrotel:xain:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"xain">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"xain">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:emetrotel:xain:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 sweet_xml_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"sweet_xml">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"sweet_xml">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:kbrw:sweet_xml:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"sweet_xml">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"sweet_xml">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:kbrw:sweet_xml:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 erlang_otp_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"erlang/otp">>, <<"28.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"erlang/otp">>, <<"28.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:erlang\/otp:28.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"erlang/otp">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"erlang/otp">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:erlang\/otp:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 rebar3_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"rebar3">>, <<"3.14.1">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"rebar3">>, <<"3.14.1">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:rebar3:3.14.1:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"rebar3">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"rebar3">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:rebar3:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 elixir_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"elixir">>, <<"1.19.3">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"elixir">>, <<"1.19.3">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-lang:elixir:1.19.3:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"elixir">>, undefined, undefined),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"elixir">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-lang:elixir:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 default_behavior_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"my_package">>, <<"1.0.0">>, <<"https://github.com/my_org/my_package">>),
+    CPE = rebar3_sbom_cpe:cpe(<<"my_package">>, <<"1.0.0">>, <<"https://github.com/my_org/my_package">>),
     ?assertEqual(<<"cpe:2.3:a:my_org:my_package:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:hex(<<"my_package">>, undefined, <<"https://github.com/my_org/my_package">>),
+    CPENoVersion = rebar3_sbom_cpe:cpe(<<"my_package">>, undefined, <<"https://github.com/my_org/my_package">>),
     ?assertEqual(<<"cpe:2.3:a:my_org:my_package:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 no_url_test(_) ->
-    CPE = rebar3_sbom_cpe:hex(<<"non_hex_package">>, <<"1.0.0">>, undefined),
+    CPE = rebar3_sbom_cpe:cpe(<<"non_hex_package">>, <<"1.0.0">>, undefined),
     ?assertEqual(undefined, CPE).

--- a/test/rebar3_sbom_purl_SUITE.erl
+++ b/test/rebar3_sbom_purl_SUITE.erl
@@ -1,0 +1,78 @@
+-module(rebar3_sbom_purl_SUITE).
+
+% CT Exports
+-export([all/0]).
+
+% Testcases
+-export([hex_purl_test/1]).
+-export([github_purl_test/1]).
+-export([bitbucket_purl_test/1]).
+-export([git_github_variants_test/1]).
+-export([git_bitbucket_variants_test/1]).
+-export([git_unsupported_host_test/1]).
+-export([local_purl_test/1]).
+-export([local_otp_app_purl_test/1]).
+
+% Includes
+-include_lib("stdlib/include/assert.hrl").
+
+%--- Common test functions -----------------------------------------------------
+
+all() -> [hex_purl_test,
+          github_purl_test,
+          bitbucket_purl_test,
+          git_github_variants_test,
+          git_bitbucket_variants_test,
+          git_unsupported_host_test,
+          local_otp_app_purl_test,
+          local_purl_test].
+
+%--- Test cases ----------------------------------------------------------------
+
+hex_purl_test(_) ->
+    Purl = rebar3_sbom_purl:hex("Rebar3_SBOM", "1.2.3"),
+    ?assertEqual(<<"pkg:hex/rebar3_sbom@1.2.3">>, Purl).
+
+github_purl_test(_) ->
+    Purl = rebar3_sbom_purl:github("ExampleOrg/ExampleRepo", "1.0.0"),
+    ?assertEqual(<<"pkg:github/exampleorg/examplerepo@1.0.0">>, Purl).
+
+git_github_variants_test(_) ->
+    Urls = ["git@github.com:ExampleOrg/ExampleRepo.git",
+            "https://github.com/ExampleOrg/ExampleRepo.git",
+            "git://github.com/ExampleOrg/ExampleRepo.git"],
+    lists:foreach(
+      fun(Url) ->
+          Purl = rebar3_sbom_purl:git("example_app", Url, "3.0.0"),
+          ?assertEqual(<<"pkg:github/exampleorg/examplerepo@3.0.0">>, Purl)
+      end,
+      Urls).
+
+bitbucket_purl_test(_) ->
+    Purl = rebar3_sbom_purl:bitbucket("ExampleOrg/ExampleRepo", "2.0.0"),
+    ?assertEqual(<<"pkg:bitbucket/exampleorg/examplerepo@2.0.0">>, Purl).
+
+git_bitbucket_variants_test(_) ->
+    Urls = ["git@bitbucket.org:ExampleOrg/ExampleRepo.git",
+            "https://bitbucket.org/ExampleOrg/ExampleRepo.git",
+            "git://bitbucket.org/ExampleOrg/ExampleRepo.git"],
+    lists:foreach(
+      fun(Url) ->
+          Purl = rebar3_sbom_purl:git("example_app", Url, "4.0.0"),
+          ?assertEqual(<<"pkg:bitbucket/exampleorg/examplerepo@4.0.0">>, Purl)
+      end,
+      Urls).
+
+git_unsupported_host_test(_) ->
+    ?assertEqual(undefined,
+                 rebar3_sbom_purl:git("example_app",
+                                      "git@gitlab.com:ExampleOrg/ExampleRepo.git",
+                                      "5.0.0")).
+
+local_otp_app_purl_test(_) ->
+    Purl = rebar3_sbom_purl:local_otp_app("Local-App", "0.9.0"),
+    ?assertEqual(<<"pkg:otp/local-app@0.9.0">>, Purl).
+
+local_purl_test(_) ->
+    Purl = rebar3_sbom_purl:local("Local-App", "0.9.0"),
+    ?assertEqual(<<"pkg:generic/local-app@0.9.0">>, Purl).


### PR DESCRIPTION
This PR introduces support for handling local checkout dependencies (rebar3 `_checkouts`) and refactors the CPE and PURL generation logic to cover more dependency types and edge cases.

### Changes

**Local Dependencies**
- Added support for `checkout` dependencies (dependencies found in `_checkouts/`).
- Introduced `pkg:otp` PURL type for local OTP application dependencies.
- Added `pkg:generic` PURL type for other local dependencies.

**CPE Generation**
- Refactored `rebar3_sbom_cpe` functions name. The previous names were too restrictive. (renamed function calls in `rebar3_sbom_cpe_SUITE` as well)
- Improved CPE generation for Git dependencies, now correctly handling `tag`, `branch`, and `ref` types.
- Added support for parsing SSH-style GitHub URLs (`git@github.com:...`) to correctly extract organization names for CPEs.

**PURL Enhancements**
- Added `rebar3_sbom_purl:local_otp_app/2` and `rebar3_sbom_purl:local/2` to support local OTP apps and local non-otp apps. See dataflow [here](https://github.com/package-url/purl-spec/pull/472) for more details

### Testing
- Added `test/rebar3_sbom_purl_SUITE.erl` to cover PURL generation for Hex, GitHub, Bitbucket, and local packages. This was lacking and adding `rebar3_sbom_purl:local_otp_app/2` and `rebar3_sbom_purl:local/2` made me add the SUITE.
- Added `checkout_app_dependency_test` to `rebar3_sbom_json_SUITE` to verify SBOM output for local checkout apps + corresponding local app in "test/local_app/_checkouts".

### Note
I tried to add test cases for dependencies coming from GitHub but rebar3 seemed unable to fetch them during the initialization phase so I gave up. However, I tested them locally using a sandbox app and I can confirm that they are working.