### PR TITLE
Add validation test for JSON

### DIFF
--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -96,9 +96,15 @@ jobs:
           otp-version: ${{ matrix.otp }}
           rebar3-version: ${{ needs.detectToolVersions.outputs.rebar3Version }}
 
+      - name: "Install Test OS Dependencies"
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          brew tap cyclonedx/cyclonedx
+          brew install cyclonedx/cyclonedx/cyclonedx-cli
+
       - name: "Run CT Suites"
         run: rebar3 ct --cover
-        continue-on-error: ${{ matrix.unstable }}
 
       - name: "Create HTML Coverage Report"
         run: rebar3 cover
@@ -114,7 +120,7 @@ jobs:
           format: cobertura
           flag-name: ct-${{ matrix.name }}
           parallel: true
-      
+
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: coverage-ct-${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -143,3 +143,15 @@ You can use either the standard CycloneDX type names or the community convention
     ]}
 ]}.
 ```
+
+Development
+-----------
+
+To run the full test suite locally, you need the CycloneDX CLI (`cyclonedx-cli`) available on your `PATH`, as it is used by `rebar3_sbom_validation_SUITE` to validate generated SBOMs.
+
+For example, on macOS or Linux with Homebrew:
+
+    brew tap cyclonedx/cyclonedx
+    brew install cyclonedx/cyclonedx/cyclonedx-cli
+
+More informations about the tool: https://github.com/CycloneDX/cyclonedx-cli

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -78,7 +78,7 @@ individual_to_json(Individual) ->
 metadata_to_json(Metadata) ->
     prune_content(#{
         timestamp => bin(Metadata#metadata.timestamp),
-        tools => [component_to_json(T) || T <- Metadata#metadata.tools],
+        tools => #{components => [component_to_json(T) || T <- Metadata#metadata.tools]},
         component => component_to_json(Metadata#metadata.component),
         manufacturer => manufacturer_to_json(Metadata#metadata.manufacturer),
         authors => individuals_to_json(Metadata#metadata.authors),
@@ -102,9 +102,9 @@ address_to_json(Address) ->
         country => bin(Address#address.country),
         region => bin(Address#address.region),
         locality => bin(Address#address.locality),
-        post_office_box_number => bin(Address#address.post_office_box_number),
-        postal_code => bin(Address#address.postal_code),
-        street_address => bin(Address#address.street_address)
+        postOfficeBoxNumber => bin(Address#address.post_office_box_number),
+        postalCode => bin(Address#address.postal_code),
+        streetAddress => bin(Address#address.street_address)
     }).
 
 -spec urls_to_json([string()]) -> [string()].

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -408,8 +408,8 @@ timestamp_test(Config) ->
 tools_test(Config) ->
     % Assume that in basic_app we only have a component for rebar3_sbom
     #{<<"tools">> := Tools} = ?config(metadata, Config),
-    ?assertMatch([_], Tools),
-    [Tool] = Tools,
+    ?assertMatch(#{<<"components">> := [_|_]}, Tools),
+    #{<<"components">> := [Tool]} = Tools,
     check_component_constraints(Tool),
     #{
         <<"type">> := Type,
@@ -519,8 +519,8 @@ manufacturer_test(Config) ->
             <<"country">> := <<"Middle-earth">>,
             <<"region">> := <<"Shire">>,
             <<"locality">> := <<"Hobbiton">>,
-            <<"postal_code">> := <<"12345">>,
-            <<"street_address">> := <<"Bag End, Hobbiton, Shire">>
+            <<"postalCode">> := <<"12345">>,
+            <<"streetAddress">> := <<"Bag End, Hobbiton, Shire">>
         },
         Address
     ),

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -408,7 +408,7 @@ timestamp_test(Config) ->
 tools_test(Config) ->
     % Assume that in basic_app we only have a component for rebar3_sbom
     #{<<"tools">> := Tools} = ?config(metadata, Config),
-    ?assertMatch(#{<<"components">> := [_|_]}, Tools),
+    ?assertMatch(#{<<"components">> := [_ | _]}, Tools),
     #{<<"components">> := [Tool]} = Tools,
     check_component_constraints(Tool),
     #{

--- a/test/rebar3_sbom_test_utils.erl
+++ b/test/rebar3_sbom_test_utils.erl
@@ -1,0 +1,47 @@
+%% SPDX-License-Identifier: BSD-3-Clause
+%% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
+
+-module(rebar3_sbom_test_utils).
+
+-export([get_app_dir/2]).
+-export([init_rebar_state/2]).
+-export([build_dir_path/2]).
+
+%--- Includes ------------------------------------------------------------------
+
+-include_lib("common_test/include/ct.hrl").
+
+%--- API -----------------------------------------------------------------------
+get_app_dir(DataDir, AppName) ->
+    SplitDataDir = filename:split(DataDir),
+    JoinedParentDir = filename:join(lists:droplast(SplitDataDir)),
+    AppDir = filename:join(JoinedParentDir, AppName),
+    true = filelib:is_dir(AppDir),
+    AppDir.
+
+init_rebar_state(Config, AppName) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    AppDir = get_app_dir(DataDir, AppName),
+    BaseDir = build_dir_path(PrivDir, AppName),
+    State = rebar_state:new([
+        {base_dir, BaseDir},
+        {root_dir, AppDir}
+    ]),
+    RebarConfig = rebar_config:consult(AppDir),
+    State2 = rebar_state:new(State, RebarConfig, AppDir),
+    {ok, State3} = rebar3_sbom_prv:init(State2),
+    add_fake_plugin_dep(State3, DataDir).
+
+build_dir_path(PrivDir, AppName) ->
+    filename:join([PrivDir, "_build_" ++ AppName]).
+
+add_fake_plugin_dep(State, DataDir) ->
+    SplitDataDir = filename:split(DataDir),
+    [_ | ReversedPluginDir] = lists:dropwhile(
+        fun(Dir) -> Dir =/= "_build" end, lists:reverse(SplitDataDir)
+    ),
+    PluginDir = filename:join(lists:reverse(ReversedPluginDir)),
+    {ok, FakePluginEntry} = rebar_app_info:discover(PluginDir, State),
+    FakePluginEntry2 = rebar_app_info:source(FakePluginEntry, checkout),
+    rebar_state:all_plugin_deps(State, [FakePluginEntry2]).

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -1,0 +1,82 @@
+%% SPDX-License-Identifier: BSD-3-Clause
+%% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
+
+-module(rebar3_sbom_validation_SUITE).
+
+% CT Exports
+-export([all/0]).
+-export([init_per_suite/1, end_per_suite/1]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+
+% Testcases
+-export([validate_json_test/1]).
+-export([validate_xml_test/1]).
+
+% Includes
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%--- Macros --------------------------------------------------------------------
+
+-define(VALIDATION_SBOM_JSON, "validation_sbom.json").
+-define(VALIDATION_SBOM_XML, "validation_sbom.xml").
+
+%--- Common test functions -----------------------------------------------------
+
+all() ->
+    [validate_json_test,
+    validate_xml_test].
+
+init_per_suite(Config) ->
+    application:load(rebar3_sbom),
+    [{cyclonedx_cli_path, cyclonedx_cli_path()} | Config].
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_testcase(validate_json_test, Config) ->
+    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    PrivDir = ?config(priv_dir, Config),
+    SBoMPath = filename:join(PrivDir, ?VALIDATION_SBOM_JSON),
+    Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f", "-a", "Jane Doe"],
+    {ok, _FinalState} = rebar3:run(State, Cmd),
+    [{sbom_path, SBoMPath} | Config];
+init_per_testcase(validate_xml_test, Config) ->
+    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    PrivDir = ?config(priv_dir, Config),
+    SBoMPath = filename:join(PrivDir, ?VALIDATION_SBOM_XML),
+    Cmd = ["sbom", "-F", "xml", "-o", SBoMPath, "-V", "false", "-f", "-a", "Jane Doe"],
+    {ok, _FinalState} = rebar3:run(State, Cmd),
+    [{sbom_path, SBoMPath} | Config];
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, Config) ->
+    Config.
+
+%--- Testcases ----------------------------------------------------------------
+validate_json_test(Config) ->
+    SBoMPath = ?config(sbom_path, Config),
+    CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
+    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--output-format", "json"],
+    {ok, Output} = os:cmd(lists:join(" " , Cmd)),
+    ?assertEqual(0, Output).
+
+validate_xml_test(Config) ->
+    SBoMPath = ?config(sbom_path, Config),
+    CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
+    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--output-format", "xml"],
+    {ok, Output} = os:cmd(Cmd),
+    ?assertEqual(0, Output).
+
+%--- Private -------------------------------------------------------------------
+
+cyclonedx_cli_path() ->
+    Names = ["cyclonedx-cli", "cyclonedx"],
+    Paths = [os:find_executable(Name) || Name <- Names],
+    case lists:filter(fun(Path) -> Path =/= false end, Paths) of
+        [] ->
+            ct:fail("CycloneDX CLI not found");
+        [ValidPath | _] ->
+            ValidPath
+    end.

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -61,7 +61,7 @@ validate_json_test(Config) ->
     SBoMPath = ?config(sbom_path, Config),
     CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
     Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--input-format", "json"],
-    Output = os:cmd(lists:join(" " , Cmd)),
+    Output = os:cmd(lists:join(" ", Cmd)),
     ?assertEqual("BOM validated successfully.\n", Output).
 
 validate_xml_test(Config) ->

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -23,9 +23,11 @@
 
 %--- Common test functions -----------------------------------------------------
 
+% all() ->
+%     [validate_json_test,
+%     validate_xml_test].
 all() ->
-    [validate_json_test,
-    validate_xml_test].
+    [validate_json_test].
 
 init_per_suite(Config) ->
     application:load(rebar3_sbom),
@@ -58,14 +60,14 @@ end_per_testcase(_, Config) ->
 validate_json_test(Config) ->
     SBoMPath = ?config(sbom_path, Config),
     CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
-    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--output-format", "json"],
-    {ok, Output} = os:cmd(lists:join(" " , Cmd)),
-    ?assertEqual(0, Output).
+    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--input-format", "json"],
+    Output = os:cmd(lists:join(" " , Cmd)),
+    ?assertEqual("BOM validated successfully.\n", Output).
 
 validate_xml_test(Config) ->
     SBoMPath = ?config(sbom_path, Config),
     CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
-    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--output-format", "xml"],
+    Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--input-format", "xml"],
     {ok, Output} = os:cmd(Cmd),
     ?assertEqual(0, Output).
 


### PR DESCRIPTION
This PR adds a CycloneDX validation test suite and fixes the JSON structure of `metadata.tools`.

- **Validation test suite**
  - Introduces `rebar3_sbom_validation_SUITE` which uses `cyclonedx-cli validate` to verify the generated JSON SBOM.
  - A corresponding XML test is already implemented but currently commented out because XML support is still broken.
 
 The validation test suite uses the "CycloneDX-cli". More informations can be found [here](https://github.com/CycloneDX/cyclonedx-cli)

- **Fix `metadata.tools` format**
  - While adding the validation, I noticed that `metadata.tools` did not match the expected CycloneDX JSON format.
  - This PR updates the JSON encoder and tests so that tools are emitted as a `components` list under `metadata.tools`, aligned with the CycloneDX specification.