### PR TITLE
Fix xml support

### DIFF
--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -269,22 +269,22 @@ decode(FilePath, "xml") ->
 decode(FilePath, "json") ->
     rebar3_sbom_json:decode(FilePath).
 
--spec normalize_sbom(#sbom{}) -> #sbom{}.
+-spec normalize_sbom(rebar3_sbom:sbom()) -> rebar3_sbom:sbom().
 normalize_sbom(#sbom{metadata = Metadata0, components = Components0, dependencies = Deps0} = S) ->
     Components = lists:map(fun normalize_component/1, dedup(Components0)),
     Metadata = normalize_metadata(Metadata0),
     Deps = normalize_deps(Deps0),
     S#sbom{metadata = Metadata, components = Components, dependencies = Deps}.
 
--spec normalize_metadata(#metadata{}) -> #metadata{}.
+-spec normalize_metadata(rebar3_sbom:metadata()) -> rebar3_sbom:metadata().
 normalize_metadata(#metadata{authors = Authors0, licenses = Licenses0} = M) ->
     M#metadata{authors = dedup(Authors0), licenses = dedup(Licenses0)}.
 
--spec normalize_component(#component{}) -> #component{}.
+-spec normalize_component(rebar3_sbom:component()) -> rebar3_sbom:component().
 normalize_component(#component{authors = Authors0, licenses = Licenses0} = C) ->
     C#component{authors = dedup(Authors0), licenses = dedup(Licenses0)}.
 
--spec normalize_deps([#dependency{}]) -> [#dependency{}].
+-spec normalize_deps([rebar3_sbom:dependency()]) -> [rebar3_sbom:dependency()].
 normalize_deps(Deps0) ->
     Deps1 = [D#dependency{dependencies = normalize_deps(D#dependency.dependencies)} || D <- Deps0],
     dedup(Deps1).

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -275,7 +275,7 @@ dep_info(_Name, _Version, {pkg, Name, Version, _InnerChecksum, OuterChecksum, _R
         {cpe, rebar3_sbom_cpe:cpe(Name, Version, GitHubLink)}
         | Common
     ];
-dep_info(Name, DepVersion, {git, Git, GitRef}, Common) ->
+dep_info(Name, _DepVersion, {git, Git, GitRef}, Common) ->
     {Version, Purl, CPE} =
         case GitRef of
             {tag, Tag} ->
@@ -285,10 +285,10 @@ dep_info(Name, DepVersion, {git, Git, GitRef}, Common) ->
                 GeneratedCPE = rebar3_sbom_cpe:cpe(
                     Name, list_to_binary(Branch), list_to_binary(Git)
                 ),
-                {DepVersion, rebar3_sbom_purl:git(Name, Git, Branch), GeneratedCPE};
+                {Branch, rebar3_sbom_purl:git(Name, Git, Branch), GeneratedCPE};
             {ref, Ref} ->
                 GeneratedCPE = rebar3_sbom_cpe:cpe(Name, list_to_binary(Ref), list_to_binary(Git)),
-                {DepVersion, rebar3_sbom_purl:git(Name, Git, Ref), GeneratedCPE}
+                {Ref, rebar3_sbom_purl:git(Name, Git, Ref), GeneratedCPE}
         end,
     [
         {name, Name},

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -69,11 +69,13 @@ tools_to_xml(Tools) ->
 organization_to_xml(OrganizationType, undefined) ->
     {OrganizationType, [undefined]};
 organization_to_xml(OrganizationType, Organization) ->
-    Content = prune_content([
-        {name, [Organization#organization.name]},
-        address_to_xml(Organization#organization.address)
-    ] ++ [{url, [Url]} || Url <- Organization#organization.url]
-      ++ [contact_to_xml(Contact) || Contact <- Organization#organization.contact]),
+    Content = prune_content(
+        [
+            {name, [Organization#organization.name]},
+            address_to_xml(Organization#organization.address)
+        ] ++ [{url, [Url]} || Url <- Organization#organization.url] ++
+            [contact_to_xml(Contact) || Contact <- Organization#organization.contact]
+    ),
     {OrganizationType, Content}.
 
 address_to_xml(Address) ->
@@ -112,8 +114,13 @@ component_to_xml(C) ->
     {component, Attributes, Content}.
 
 prune_content(Content) ->
-    lists:filter(fun({_, [Value]}) -> Value =/= undefined;
-                    (Field) -> Field =/= undefined end, Content).
+    lists:filter(
+        fun
+            ({_, [Value]}) -> Value =/= undefined;
+            (Field) -> Field =/= undefined
+        end,
+        Content
+    ).
 
 component_field_to_xml(authors, Authors) ->
     {authors, [author_to_xml(Author) || Author <- Authors]};

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -74,7 +74,7 @@ organization_to_xml(OrganizationType, Organization) ->
             {name, [Organization#organization.name]},
             address_to_xml(Organization#organization.address)
         ] ++ [{url, [Url]} || Url <- Organization#organization.url] ++
-            [contact_to_xml(Contact) || Contact <- Organization#organization.contact]
+            [individual_to_xml(contact, Contact) || Contact <- Organization#organization.contact]
     ),
     {OrganizationType, Content}.
 
@@ -88,14 +88,6 @@ address_to_xml(Address) ->
         {streetAddress, [Address#address.street_address]}
     ]),
     {address, Content}.
-
-contact_to_xml(Contact) ->
-    Content = prune_content([
-        {name, [Contact#individual.name]},
-        {email, [Contact#individual.email]},
-        {phone, [Contact#individual.phone]}
-    ]),
-    {contact, Content}.
 
 component_to_xml(C) ->
     Attributes = [{type, C#component.type}, {'bom-ref', C#component.bom_ref}],
@@ -123,7 +115,7 @@ prune_content(Content) ->
     ).
 
 component_field_to_xml(authors, Authors) ->
-    {authors, [author_to_xml(Author) || Author <- Authors]};
+    {authors, [individual_to_xml(author, Author) || Author <- Authors]};
 component_field_to_xml(hashes, Hashes) ->
     {hashes, [hash_to_xml(Hash) || Hash <- Hashes]};
 component_field_to_xml(licenses, Licenses) ->
@@ -135,13 +127,13 @@ component_field_to_xml(scope, Scope) ->
 component_field_to_xml(FieldName, Value) ->
     {FieldName, [Value]}.
 
-author_to_xml(Author) ->
+individual_to_xml(IndividualType, Individual) ->
     Content = prune_content([
-        {name, [Author#individual.name]},
-        {email, [Author#individual.email]},
-        {phone, [Author#individual.phone]}
+        {name, [Individual#individual.name]},
+        {email, [Individual#individual.email]},
+        {phone, [Individual#individual.phone]}
     ]),
-    {author, Content}.
+    {IndividualType, Content}.
 
 hash_to_xml(#{alg := Alg, hash := Hash}) ->
     {hash, [{alg, Alg}], [Hash]}.

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -71,10 +71,9 @@ organization_to_xml(OrganizationType, undefined) ->
 organization_to_xml(OrganizationType, Organization) ->
     Content = prune_content([
         {name, [Organization#organization.name]},
-        {address, [address_to_xml(Organization#organization.address)]},
-        {url, [Url || Url <- Organization#organization.url]},
-        {contact, [contact_to_xml(Contact) || Contact <- Organization#organization.contact]}
-    ]),
+        address_to_xml(Organization#organization.address)
+    ] ++ [{url, [Url]} || Url <- Organization#organization.url]
+      ++ [contact_to_xml(Contact) || Contact <- Organization#organization.contact]),
     {OrganizationType, Content}.
 
 address_to_xml(Address) ->
@@ -82,9 +81,9 @@ address_to_xml(Address) ->
         {country, [Address#address.country]},
         {region, [Address#address.region]},
         {locality, [Address#address.locality]},
-        {post_office_box_number, [Address#address.post_office_box_number]},
-        {postal_code, [Address#address.postal_code]},
-        {street_address, [Address#address.street_address]}
+        {postOfficeBoxNumber, [Address#address.post_office_box_number]},
+        {postalCode, [Address#address.postal_code]},
+        {streetAddress, [Address#address.street_address]}
     ]),
     {address, Content}.
 

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -23,10 +23,11 @@
 
 %--- Common test functions -----------------------------------------------------
 
-all() -> [
-    validate_json_test,
-    validate_xml_test
-].
+all() ->
+    [
+        validate_json_test,
+        validate_xml_test
+    ].
 
 init_per_suite(Config) ->
     application:load(rebar3_sbom),

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -76,7 +76,15 @@ validate_xml_test(Config) ->
 cyclonedx_cli_path() ->
     Names = ["cyclonedx-cli", "cyclonedx"],
     Paths = [os:find_executable(Name) || Name <- Names],
-    case lists:filter(fun(Path) -> Path =/= false end, Paths) of
+    case
+        lists:filter(
+            fun
+                (false) -> false;
+                (_) -> true
+            end,
+            Paths
+        )
+    of
         [] ->
             ct:fail("CycloneDX CLI not found");
         [ValidPath | _] ->

--- a/test/rebar3_sbom_validation_SUITE.erl
+++ b/test/rebar3_sbom_validation_SUITE.erl
@@ -23,11 +23,10 @@
 
 %--- Common test functions -----------------------------------------------------
 
-% all() ->
-%     [validate_json_test,
-%     validate_xml_test].
-all() ->
-    [validate_json_test].
+all() -> [
+    validate_json_test,
+    validate_xml_test
+].
 
 init_per_suite(Config) ->
     application:load(rebar3_sbom),
@@ -68,8 +67,8 @@ validate_xml_test(Config) ->
     SBoMPath = ?config(sbom_path, Config),
     CycloneDXCLIPath = ?config(cyclonedx_cli_path, Config),
     Cmd = [CycloneDXCLIPath, "validate", "--input-file", SBoMPath, "--input-format", "xml"],
-    {ok, Output} = os:cmd(Cmd),
-    ?assertEqual(0, Output).
+    Output = os:cmd(lists:join(" ", Cmd)),
+    ?assertEqual("BOM validated successfully.\n", Output).
 
 %--- Private -------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

This PR fixes a crash when generating XML SBOMs and ensures the output is fully compliant with the CycloneDX 1.6 schema. It also achieves feature parity with the JSON format and improves version handling for Git dependencies.

### Key Changes
- **Crash Fix & Compliance**: Resolved runtime errors in the XML generator and fixed invalid nesting/naming to match the CycloneDX 1.6 XML schema.
- **Feature Parity**: Added missing fields to the XML output (`cpe`, `scope`, `externalReferences`, `authors`, `licenses`) to match JSON capabilities.
- **Git Dependencies**: The version of dependencies defined by Git branch or ref is now omitted
- **Validation**: Added `rebar3_sbom_validation_SUITE` to validate generated BOMs using the `cyclonedx-cli`.