### PR TITLE
fix parsing error

### DIFF
--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -38,10 +38,10 @@ bom({FilePath, _} = FileInfo, IsStrictVersion, App, Plugin, Serial, MetadataInfo
         SBoM#sbom{version = V}
     catch
         _:Reason:_Stacktrace ->
-            logger:error(
-                "scan file:~ts failed, reason:~p, will use the default version number ~p",
-                [FilePath, Reason, ?DEFAULT_VERSION]
-            ),
+        rebar_api:error(
+            "scan file:~ts failed, reason:~p, will use the default version number ~p",
+            [FilePath, Reason, ?DEFAULT_VERSION]
+        ),
             SBoM
     end.
 
@@ -246,7 +246,7 @@ version(IsStrictVersion, {_, OldSBoM}) when not (IsStrictVersion) ->
         "Incrementing the SBoM version unconditionally: strict_version is set to false.", []
     ),
     OldSBoM#sbom.version + 1;
-version(IsStrictVersion, {NewSBoM, OldSBoM}) when not (IsStrictVersion) ->
+version(IsStrictVersion, {NewSBoM, OldSBoM}) when IsStrictVersion ->
     case is_sbom_equal(NewSBoM, OldSBoM) of
         true ->
             rebar_api:info(

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -38,10 +38,10 @@ bom({FilePath, _} = FileInfo, IsStrictVersion, App, Plugin, Serial, MetadataInfo
         SBoM#sbom{version = V}
     catch
         _:Reason:_Stacktrace ->
-        rebar_api:error(
-            "scan file:~ts failed, reason:~p, will use the default version number ~p",
-            [FilePath, Reason, ?DEFAULT_VERSION]
-        ),
+            rebar_api:error(
+                "scan file:~ts failed, reason:~p, will use the default version number ~p",
+                [FilePath, Reason, ?DEFAULT_VERSION]
+            ),
             SBoM
     end.
 


### PR DESCRIPTION
Changes in `rebar3_sbom_cyclondx.erl` was making the parsing of a previously generated sbom fail.

```
rebar3 sbom -F json -a "Gwendal Laurent" -f
===> Fetching jsone v1.9.0
===> Analyzing applications...
===> Compiling jsone
===> Compiling rebar3_sbom
===> Verifying dependencies...
===> Fetching cowboy v2.14.0
===> Fetching grisp v2.9.0
===> Fetching hex_core v0.11.0
===> Fetching meck (from {git,"git@github.com:eproxus/meck.git",{branch,"master"}})
===> Fetching purl v0.3.0
===> Fetching cowlib v2.16.0
===> Fetching mapz v2.3.0
===> Skipping mapz v2.4.0 as an app of the same name has already been fetched
===> Fetching stream_data v1.2.0
===> App abac is a checkout dependency and cannot be locked.
[...]
=ERROR REPORT==== 3-Dec-2025::16:37:58.001564 ===
scan file:./bom.json failed, reason:function_clause, will use the default version number 1
```

This PR fixes that.
Moreover, the error was displayed using the builtin logger and the output was displayed like a regular log. This PR changes that and uses `rebar_api:error` to display the error in red