### PR TITLE
[bugfix] SBoM parsing in JSON and XML

### DIFF
--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -173,6 +173,17 @@ json_to_component_field(<<"licenses">> = F, Component) ->
     json_to_licenses(maps:get(F, Component, undefined));
 json_to_component_field(<<"externalReferences">> = F, Component) ->
     json_to_external_references(maps:get(F, Component, undefined));
+json_to_component_field(<<"scope">> = F, Component) ->
+    case maps:get(F, Component, undefined) of
+        undefined ->
+            undefined;
+        Scope ->
+            case Scope of
+                <<"required">> -> required;
+                <<"optional">> -> optional;
+                <<"excluded">> -> excluded
+            end
+        end;
 json_to_component_field(FieldName, Component) ->
     str(maps:get(FieldName, Component, undefined)).
 
@@ -181,8 +192,12 @@ json_to_authors(undefined) ->
 json_to_authors(Authors) ->
     [json_to_author(A) || A <- Authors].
 
-json_to_author(#{<<"name">> := Name}) ->
-    #{name => str(Name)}.
+json_to_author(Author) ->
+    #individual{
+        name = str(maps:get(<<"name">>, Author, undefined)),
+        email = str(maps:get(<<"email">>, Author, undefined)),
+        phone = str(maps:get(<<"phone">>, Author, undefined))
+    }.
 
 json_to_hashes(undefined) ->
     undefined;

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -183,7 +183,7 @@ json_to_component_field(<<"scope">> = F, Component) ->
                 <<"optional">> -> optional;
                 <<"excluded">> -> excluded
             end
-        end;
+    end;
 json_to_component_field(FieldName, Component) ->
     str(maps:get(FieldName, Component, undefined)).
 

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -172,20 +172,26 @@ xml_to_component(Component) ->
     #component{
         type = Type,
         bom_ref = BomRef,
-        authors = replace_if_empty(Authors),
+        authors = Authors,
         name = xml_to_component_field(Name),
         version = xml_to_component_field(Version),
         description = xml_to_component_field(Description),
         scope = xml_to_component_field(Scope),
         purl = xml_to_component_field(Purl),
         cpe = xml_to_component_field(Cpe),
-        hashes = replace_if_empty(Hashes),
-        licenses = replace_if_empty(Licenses),
-        externalReferences = replace_if_empty(ExternalReferences)
+        hashes = Hashes,
+        licenses = Licenses,
+        externalReferences = ExternalReferences
     }.
 
 xml_to_component_field([]) ->
     undefined;
+xml_to_component_field([#xmlText{parents = [{scope, _} | _], value = Value}]) ->
+    case Value of
+        "required" -> required;
+        "optional" -> optional;
+        "excluded" -> excluded
+    end;
 xml_to_component_field([#xmlText{value = Value}]) ->
     Value.
 
@@ -214,8 +220,3 @@ xml_to_license(LicenseElement) ->
 
 xpath(String, Xml) ->
     xmerl_xpath:string(String, Xml).
-
-replace_if_empty([]) ->
-    undefined;
-replace_if_empty(List) ->
-    List.


### PR DESCRIPTION
With our recent changes in the internal representation of the SBoM, the comparaison between a previously generated SBoM and a new SBoM was broken. In "Strict mode", this resulted by generating a new SBoM even though the content of the SBoM didn't change.

This PR fixes that by updating the parsing of the json and the xml. A new test case for the JSON generation is also added