### PR TITLE
Fix internal representation of licence

### DIFF
--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -58,7 +58,7 @@
     bom_ref :: bom_ref() | undefined,
     id :: spdx_licence_id() | undefined,
     name :: string() | undefined,
-    acknowledgement :: declared | concluded,
+    acknowledgement :: declared | concluded | undefined,
     properties = [] :: properties()
 }).
 

--- a/include/rebar3_sbom.hrl
+++ b/include/rebar3_sbom.hrl
@@ -55,9 +55,9 @@
 
 % Not adding Text, URL, Licensing for now
 -record(license, {
-    bom_ref :: bom_ref(),
-    id :: spdx_licence_id(),
-    name :: string(),
+    bom_ref :: bom_ref() | undefined,
+    id :: spdx_licence_id() | undefined,
+    name :: string() | undefined,
     acknowledgement :: declared | concluded,
     properties = [] :: properties()
 }).

--- a/src/rebar3_sbom_cyclonedx.erl
+++ b/src/rebar3_sbom_cyclonedx.erl
@@ -135,12 +135,14 @@ component_field(Field, RawComponent) ->
             Else
     end.
 
+license(Name) when is_binary(Name) ->
+    license(binary:bin_to_list(Name));
 license(Name) ->
     case rebar3_sbom_license:spdx_id(Name) of
         undefined ->
-            #{name => Name};
+            #license{name = Name};
         SpdxId ->
-            #{id => SpdxId}
+            #license{id = SpdxId}
     end.
 
 -spec manufacturer(ManufacturerIn) -> ManufacturerOut when

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -129,10 +129,12 @@ licenses_to_json(Licenses) ->
     [license_to_json(L) || L <- Licenses].
 
 license_to_json(License) ->
-    #{license => prune_content(#{
-        name => bin(License#license.name),
-        id => bin(License#license.id)
-    })}.
+    #{
+        license => prune_content(#{
+            name => bin(License#license.name),
+            id => bin(License#license.id)
+        })
+    }.
 
 dependency_to_json(D) ->
     #{
@@ -214,8 +216,10 @@ json_to_licenses(Licenses) ->
     [json_to_license(L) || L <- Licenses].
 
 json_to_license(#{<<"license">> := License}) ->
-    #license{id = str(maps:get(<<"id">>, License, undefined)),
-             name = str(maps:get(<<"name">>, License, undefined))}.
+    #license{
+        id = str(maps:get(<<"id">>, License, undefined)),
+        name = str(maps:get(<<"name">>, License, undefined))
+    }.
 
 json_to_external_references(undefined) ->
     undefined;

--- a/src/rebar3_sbom_json.erl
+++ b/src/rebar3_sbom_json.erl
@@ -128,10 +128,11 @@ external_reference_to_json(#external_reference{type = Type, url = Url}) ->
 licenses_to_json(Licenses) ->
     [license_to_json(L) || L <- Licenses].
 
-license_to_json(#{name := Name}) ->
-    #{license => #{name => bin(Name)}};
-license_to_json(#{id := Id}) ->
-    #{license => #{id => bin(Id)}}.
+license_to_json(License) ->
+    #{license => prune_content(#{
+        name => bin(License#license.name),
+        id => bin(License#license.id)
+    })}.
 
 dependency_to_json(D) ->
     #{
@@ -212,10 +213,9 @@ json_to_licenses(undefined) ->
 json_to_licenses(Licenses) ->
     [json_to_license(L) || L <- Licenses].
 
-json_to_license(#{<<"license">> := #{<<"id">> := Id}}) ->
-    #{id => str(Id)};
-json_to_license(#{<<"license">> := #{<<"name">> := Name}}) ->
-    #{name => str(Name)}.
+json_to_license(#{<<"license">> := License}) ->
+    #license{id = str(maps:get(<<"id">>, License, undefined)),
+             name = str(maps:get(<<"name">>, License, undefined))}.
 
 json_to_external_references(undefined) ->
     undefined;

--- a/src/rebar3_sbom_xml.erl
+++ b/src/rebar3_sbom_xml.erl
@@ -138,10 +138,12 @@ individual_to_xml(IndividualType, Individual) ->
 hash_to_xml(#{alg := Alg, hash := Hash}) ->
     {hash, [{alg, Alg}], [Hash]}.
 
-license_to_xml(#{name := Name}) ->
-    {license, [{name, [Name]}]};
-license_to_xml(#{id := Id}) ->
-    {license, [{id, [Id]}]}.
+license_to_xml(License) ->
+    Content = prune_content([
+        {name, [License#license.name]},
+        {id, [License#license.id]}
+    ]),
+    {license, Content}.
 
 external_reference_to_xml(#external_reference{type = Type, url = Url}) ->
     {reference, [{type, Type}], [{url, [Url]}]}.
@@ -212,10 +214,10 @@ xml_to_external_reference(ExternalReferenceElement) ->
 xml_to_license(LicenseElement) ->
     case xpath("/license/id/text()", LicenseElement) of
         [Value] ->
-            #{id => Value#xmlText.value};
+            #license{id = Value#xmlText.value};
         [] ->
             [Value] = xpath("/license/name/text()", LicenseElement),
-            #{name => Value#xmlText.value}
+            #license{name = Value#xmlText.value}
     end.
 
 xpath(String, Xml) ->

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -818,8 +818,10 @@ check_licenses_constraints(Licenses) ->
         fun(License) ->
             ?assertMatch(#{<<"license">> := _}, License),
             #{<<"license">> := LicenseContent} = License,
-            ?assert(maps:is_key(<<"id">>, LicenseContent) orelse
-                    maps:is_key(<<"name">>, LicenseContent))
+            ?assert(
+                maps:is_key(<<"id">>, LicenseContent) orelse
+                    maps:is_key(<<"name">>, LicenseContent)
+            )
         end,
         Licenses
     ).

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -816,7 +816,10 @@ check_purl_format(Purl) ->
 check_licenses_constraints(Licenses) ->
     lists:foreach(
         fun(License) ->
-            ?assertMatch(#{<<"license">> := #{<<"id">> := _}}, License)
+            ?assertMatch(#{<<"license">> := _}, License),
+            #{<<"license">> := LicenseContent} = License,
+            ?assert(maps:is_key(<<"id">>, LicenseContent) orelse
+                    maps:is_key(<<"name">>, LicenseContent))
         end,
         Licenses
     ).


### PR DESCRIPTION
The internal representation of the licenses was still using maps instead of the defined records. 
Moreover, in some cases, the license name was a binary. This was triggering a crash in xmerl because it's only expecting strings. 

Example of the crash:
```erlang
===> Uncaught error: function_clause
===> Stack trace to the error location:
[{xmerl_lib,expand_element,
            [<<"Apache-2.0">>,1,
             [{name,1},
              {license,1},
              {licenses,7},
              {component,11},
              {components,2},
              {bom,1}],
             false],
            [{file,"xmerl_lib.erl"},{line,187}]},
 {xmerl_lib,expand_content,4,[{file,"xmerl_lib.erl"},{line,260}]},
 {xmerl_lib,expand_element,4,[{file,"xmerl_lib.erl"},{line,223}]},
 {xmerl_lib,expand_content,4,[{file,"xmerl_lib.erl"},{line,260}]},
 {xmerl_lib,expand_element,4,[{file,"xmerl_lib.erl"},{line,223}]},
 {xmerl_lib,expand_content,4,[{file,"xmerl_lib.erl"},{line,260}]},
 {xmerl_lib,expand_element,4,[{file,"xmerl_lib.erl"},{line,223}]},
 {xmerl_lib,expand_content,4,[{file,"xmerl_lib.erl"},{line,260}]}]
 ```

This PR fixes both issues by:
 1. Converting all license representations to use #license{} records consistently
 2. Ensuring license names are converted from binaries to strings before processing
 3. Updating the license constraint test as well to reflect the possibility of having either license.id or license.name