### PR TITLE
Detect if the root app is a hex package or fall back to git

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -2,48 +2,38 @@
 %% SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 [
-    {elvis, [
-        {config, [
-            #{
-                dirs => ["src"],
-                filter => "*.erl",
-                ruleset => erl_files,
-                rules =>
-                    %% Line length is the job of the formatter
-                    [
-                        {elvis_text_style, line_length, #{limit => 1_000}},
-                        %% We're exposing records
-                        {elvis_style, private_data_types, #{apply_to => []}},
-                        %% Increase min complexity for repeating code
-                        {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-                        %% Naming is dictated by Standard
-                        {elvis_style, atom_naming_convention, #{regex => ".*"}},
-                        {elvis_style, variable_naming_convention, #{regex => ".*"}}
-                    ]
-            },
-            #{
-                dirs => ["test"],
-                filter => "*.erl",
-                ruleset => erl_files,
-                rules =>
-                    %% Line length is the job of the formatter
-                    [
-                        {elvis_text_style, line_length, #{limit => 1_000}},
-                        %% Tests are ok to repeat
-                        {elvis_style, dont_repeat_yourself, #{min_complexity => 10_000}},
-                        {elvis_style, god_modules, #{limit => 1_000}}
-                    ]
-            },
-            #{
-                dirs => ["."],
-                filter => "rebar.config",
-                ruleset => rebar_config
-            },
-            #{
-                dirs => ["."],
-                filter => "elvis.config",
-                ruleset => elvis_project
-            }
-        ]}
+    {config, [
+        #{
+            files => ["src/*.erl"],
+            ruleset => erl_files,
+            rules =>
+                %% Line length is the job of the formatter
+                [
+                    {elvis_text_style, max_line_length, #{limit => 1_000}},
+                    %% We're exposing records
+                    {elvis_style, private_data_types, #{apply_to => []}},
+                    %% Increase min complexity for repeating code
+                    {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                    %% Naming is dictated by Standard
+                    {elvis_style, atom_naming_convention, #{regex => ".*"}},
+                    {elvis_style, variable_naming_convention, #{regex => ".*"}}
+                ]
+        },
+        #{
+            files => ["test/*.erl"],
+            ruleset => erl_files,
+            rules =>
+                %% Line length is the job of the formatter
+                [
+                    {elvis_text_style, max_line_length, #{limit => 1_000}},
+                    %% Tests are ok to repeat
+                    {elvis_style, dont_repeat_yourself, #{min_complexity => 10_000}},
+                    {elvis_style, no_god_modules, #{limit => 1_000}}
+                ]
+        },
+        #{
+            files => ["rebar.config"],
+            ruleset => rebar_config
+        }
     ]}
 ].

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -60,7 +60,7 @@ do(State) ->
     Force = proplists:get_value(force, Args),
     IsStrictVersion = proplists:get_value(strict_version, Args),
     [App0 | _] = rebar_state:project_apps(State),
-    App = rebar_app_info:source(App0, root_app),
+    App = rebar_app_info:source(App0, find_root_app_source(State)),
     PluginDeps = rebar_state:all_plugin_deps(State),
     {value, Plugin} = lists:search(
         fun(Plugin) ->
@@ -415,3 +415,61 @@ hash(AppInfo, BaseDir) ->
 tar_path(BaseDir, Name, Version) ->
     TarFilename = io_lib:format("~s-~s.tar.gz", [Name, Version]),
     filename:join([BaseDir, "rel", Name, TarFilename]).
+
+find_root_app_source(State) ->
+    RootDir = rebar_dir:root_dir(State),
+    case root_app_is_hex_package(RootDir) of
+        true ->
+            root_app;
+        false ->
+            find_root_app_git_source(RootDir)
+    end.
+
+root_app_is_hex_package(RootDir) ->
+    RebarConfig =
+        case rebar_config:consult(RootDir) of
+            Terms when is_list(Terms) -> Terms;
+            _ -> []
+        end,
+    proplists:is_defined(hex, RebarConfig).
+
+find_root_app_git_source(RootDir) ->
+    NormalizedRootDir = normalize_dir(RootDir),
+    case
+        {
+            run_git_command(RootDir, ["rev-parse", "--show-toplevel"]),
+            run_git_command(RootDir, ["config", "--get", "remote.origin.url"]),
+            run_git_command(RootDir, ["rev-parse", "HEAD"])
+        }
+    of
+        {{ok, RepoRoot}, {ok, Url}, {ok, Ref}} ->
+            case normalize_dir(RepoRoot) =:= NormalizedRootDir of
+                true -> {git, Url, {ref, Ref}};
+                false -> root_app
+            end;
+        _ ->
+            root_app
+    end.
+
+run_git_command(RootDir, Args) ->
+    Command = "git " ++ string:join(Args, " "),
+    case
+        rebar_utils:sh(
+            Command,
+            [{cd, RootDir}, {use_stdout, false}, {return_on_error, true}]
+        )
+    of
+        {ok, Output} ->
+            case string:trim(Output) of
+                [] -> {error, empty_output};
+                TrimmedOutput -> {ok, TrimmedOutput}
+            end;
+        {error, {Status, _Output}} ->
+            {error, Status}
+    end.
+
+normalize_dir(Path) ->
+    case filename:basename(Path) of
+        "." -> normalize_dir(filename:dirname(Path));
+        _ -> filename:absname(Path)
+    end.

--- a/src/rebar3_sbom_prv.erl
+++ b/src/rebar3_sbom_prv.erl
@@ -3,7 +3,7 @@
 %% SPDX-FileCopyrightText: 2022 lafirest
 %% SPDX-FileCopyrightText: 2024 Sebastian Strollo
 %% SPDX-FileCopyrightText: 2024 Paulo F. Oliveira
-%% SPDX-FileCopyrightText: 2024 Stritzinger GmbH
+%% SPDX-FileCopyrightText: 2024-2026 Stritzinger GmbH
 
 -module(rebar3_sbom_prv).
 

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -51,9 +51,6 @@
 -export([checkout_app_dependency_test/1]).
 -export([git_root_app_source_test/1]).
 
-% Utils imports
--import(rebar3_sbom_test_utils, [run_cmd/1]).
-
 % Includes
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -219,10 +216,7 @@ init_per_group(basic_app, Config) ->
     {ok, FinalState} = rebar3:run(State, Cmd),
     {ok, File} = file:read_file(SBoMPath),
     SBoMJSON = json:decode(File),
-    AllDeps = lists:map(
-        fun(Dep) -> atom_to_binary(Dep) end,
-        rebar_state:get(FinalState, deps)
-    ),
+    AllDeps = lists:map(fun erlang:atom_to_binary/1, rebar_state:get(FinalState, deps)),
     [
         {sbom_path, SBoMPath},
         {sbom_json, SBoMJSON},
@@ -584,12 +578,7 @@ manufacturer_test(Config) ->
 %--- components group ---
 required_component_fields_test(Config) ->
     #{<<"components">> := Components} = ?config(sbom_json, Config),
-    lists:foreach(
-        fun(Component) ->
-            check_component_constraints(Component)
-        end,
-        Components
-    ).
+    lists:foreach(fun check_component_constraints/1, Components).
 
 all_deps_present_test(Config) ->
     AllDeps = ?config(all_deps, Config),

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -49,6 +49,10 @@
 -export([metadata_component_empty_links_cpe_test/1]).
 -export([external_references_fallback_test/1]).
 -export([checkout_app_dependency_test/1]).
+-export([git_root_app_source_test/1]).
+
+% Utils imports
+-import(rebar3_sbom_test_utils, [run_cmd/1]).
 
 % Includes
 -include_lib("common_test/include/ct.hrl").
@@ -189,7 +193,8 @@ groups() ->
             no_sbom_licenses_test,
             metadata_component_empty_links_cpe_test,
             external_references_fallback_test,
-            checkout_app_dependency_test
+            checkout_app_dependency_test,
+            git_root_app_source_test
         ]}
     ].
 
@@ -337,11 +342,31 @@ init_per_testcase(strict_version_test, Config) ->
     {ok, File} = file:read_file(SBoMPath),
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON} | Config];
+init_per_testcase(git_root_app_source_test, Config) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    SrcDir = rebar3_sbom_test_utils:get_app_dir(DataDir, "local_app"),
+    AppDir = filename:join(PrivDir, "git_root_app"),
+    ok = maybe_delete_dir(AppDir),
+    {ok, _} = rebar_utils:sh(["cp -r ", SrcDir, " ", AppDir], []),
+    init_git_repo(AppDir, "https://github.com/ExampleOrg/local_app.git"),
+    State = rebar3_sbom_test_utils:init_rebar_state_from_dir(
+        Config, AppDir, "git_root_app"
+    ),
+    SBoMPath = filename:join(PrivDir, "git_root_app_sbom.json"),
+    Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
+    {ok, _FinalState} = rebar3:run(State, Cmd),
+    {ok, File} = file:read_file(SBoMPath),
+    NewSBoMJSON = json:decode(File),
+    [{sbom_json, NewSBoMJSON}, {git_root_app_dir, AppDir}, {sbom_path, SBoMPath} | Config];
 init_per_testcase(_, Config) ->
     Config.
 
 end_per_testcase(github_actor_test, _) ->
     os:unsetenv("GITHUB_ACTOR");
+end_per_testcase(git_root_app_source_test, Config) ->
+    ok = file:del_dir_r(?config(git_root_app_dir, Config)),
+    ok = file:delete(?config(sbom_path, Config));
 end_per_testcase(_, _Config) ->
     ok.
 
@@ -725,7 +750,31 @@ checkout_app_dependency_test(Config) ->
         Dependency
     ).
 
+git_root_app_source_test(Config) ->
+    SBoMJSON = ?config(sbom_json, Config),
+    #{<<"metadata">> := #{<<"component">> := Component}} = SBoMJSON,
+    #{<<"purl">> := Purl} = Component,
+    check_purl_format(Purl),
+    ?assertMatch(<<"pkg:github/exampleorg/local_app@", _/bitstring>>, Purl),
+    ?assertNotMatch(<<"pkg:hex/", _/bitstring>>, Purl).
+
 %--- Private -------------------------------------------------------------------
+
+init_git_repo(AppDir, RemoteUrl) ->
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " init -q"], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " config user.email sbom@example.com"], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " config user.name SBOM Test"], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " config commit.gpgsign false"], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " add ."], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " commit -q -m \"Initial commit\""], []),
+    {ok, _} = rebar_utils:sh(["git -C ", AppDir, " remote add origin ", RemoteUrl], []).
+
+maybe_delete_dir(Dir) ->
+    case filelib:is_dir(Dir) of
+        true -> file:del_dir_r(Dir);
+        false -> ok
+    end.
+
 check_component_constraints(Component) ->
     check_component_cyclonedx_constraints(Component),
     check_component_ort_constraints(Component).

--- a/test/rebar3_sbom_json_SUITE.erl
+++ b/test/rebar3_sbom_json_SUITE.erl
@@ -1,5 +1,5 @@
 %% SPDX-License-Identifier: BSD-3-Clause
-%% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
+%% SPDX-FileCopyrightText: 2025-2026 Stritzinger GmbH
 
 -module(rebar3_sbom_json_SUITE).
 

--- a/test/rebar3_sbom_test_utils.erl
+++ b/test/rebar3_sbom_test_utils.erl
@@ -1,5 +1,5 @@
 %% SPDX-License-Identifier: BSD-3-Clause
-%% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
+%% SPDX-FileCopyrightText: 2025-2026 Stritzinger GmbH
 
 -module(rebar3_sbom_test_utils).
 

--- a/test/rebar3_sbom_test_utils.erl
+++ b/test/rebar3_sbom_test_utils.erl
@@ -5,6 +5,7 @@
 
 -export([get_app_dir/2]).
 -export([init_rebar_state/2]).
+-export([init_rebar_state_from_dir/3]).
 -export([build_dir_path/2]).
 
 %--- Includes ------------------------------------------------------------------
@@ -21,8 +22,12 @@ get_app_dir(DataDir, AppName) ->
 
 init_rebar_state(Config, AppName) ->
     DataDir = ?config(data_dir, Config),
-    PrivDir = ?config(priv_dir, Config),
     AppDir = get_app_dir(DataDir, AppName),
+    init_rebar_state_from_dir(Config, AppDir, AppName).
+
+init_rebar_state_from_dir(Config, AppDir, AppName) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
     BaseDir = build_dir_path(PrivDir, AppName),
     State = rebar_state:new([
         {base_dir, BaseDir},


### PR DESCRIPTION
## Context

The default behaviour for this plugin is to assume that the root application is an hex package. 

This may very well not be the case. What usually is more likely is that it is a git repository... In this case we could use the remote url and the git commit hash as ingredients for the PURL of the SBOM.

## Changes

- check if the root app contains an HEX key in the config. In this case we assume is an hex package.
- check if the root app is a git repo. In this case we get the remote URL and the commit hash to define the package version

A new test case has been added