### PR TITLE
Rename plugin to rebar_sbom

### DIFF
--- a/.github/workflows/part_build.yml
+++ b/.github/workflows/part_build.yml
@@ -43,4 +43,4 @@ jobs:
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: escript
-          path: "_build/default/bin/rebar3_sbom"
+          path: "_build/default/bin/rebar_sbom"

--- a/.github/workflows/part_smoke_test.yml
+++ b/.github/workflows/part_smoke_test.yml
@@ -36,7 +36,7 @@ jobs:
               {idna, "6.1.1"}
             ]}.
             {project_plugins, [
-              {rebar3_sbom, {git, "$REPO", {ref, "$SHA"}}}
+              {rebar_sbom, {git, "$REPO", {ref, "$SHA"}}}
             ]}.
           EOF
 
@@ -95,11 +95,11 @@ jobs:
 
   #     - name: "Make EScript Executable"
   #       run: |
-  #         chmod +x ./escript_artifacts/rebar3_sbom
+  #         chmod +x ./escript_artifacts/rebar_sbom
 
   #     - name: "Test All Combinations"
   #       uses: ./.github/actions/validate-cyclonedx-bom
   #       with:
-  #         command: "./escript_artifacts/rebar3_sbom cyclonedx"
+  #         command: "./escript_artifacts/rebar_sbom cyclonedx"
   #         command-args: "."
   #         test-name: "EScript"

--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -116,7 +116,7 @@ jobs:
         if: always()
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
-          file: "_build/test/covertool/rebar3_sbom.covertool.xml"
+          file: "_build/test/covertool/rebar_sbom.covertool.xml"
           format: cobertura
           flag-name: ct-${{ matrix.name }}
           parallel: true

--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@
 # Rebar3 SBoM
 
 [![EEF Security WG project](https://img.shields.io/badge/EEF-Security-black)](https://github.com/erlef/security-wg)
-[![.github/workflows/branch_main.yml](https://github.com/erlef/rebar3_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/erlef/rebar3_sbom/actions/workflows/branch_main.yml)
-[![REUSE status](https://api.reuse.software/badge/github.com/erlef/rebar3_sbom)](https://api.reuse.software/info/github.com/erlef/rebar3_sbom)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/erlef/rebar3_sbom/badge)](https://scorecard.dev/viewer/?uri=github.com/erlef/rebar3_sbom)
-[![Coverage Status](https://coveralls.io/repos/github/erlef/rebar3_sbom/badge.svg?branch=main)](https://coveralls.io/github/erlef/rebar3_sbom?branch=main)
+[![.github/workflows/branch_main.yml](https://github.com/erlef/rebar_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/erlef/rebar_sbom/actions/workflows/branch_main.yml)
+[![REUSE status](https://api.reuse.software/badge/github.com/erlef/rebar_sbom)](https://api.reuse.software/info/github.com/erlef/rebar_sbom)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/erlef/rebar_sbom/badge)](https://scorecard.dev/viewer/?uri=github.com/erlef/rebar_sbom)
+[![Coverage Status](https://coveralls.io/repos/github/erlef/rebar_sbom/badge.svg?branch=main)](https://coveralls.io/github/erlef/rebar_sbom?branch=main)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11547/badge)](https://www.bestpractices.dev/projects/11547)
 
 Generates a Software Bill-of-Materials (SBoM) in CycloneDX format
 
 ## Use
 
-Add rebar3_sbom to your rebar config, either in a project or globally in
+Add rebar_sbom to your rebar config, either in a project or globally in
 `~/.config/rebar3/rebar.config`:
 
 ```erlang
-{plugins, [rebar3_sbom]}.
+{plugins, [rebar_sbom]}.
 ```
 
 Then run the `sbom` task on a project:
@@ -37,7 +37,7 @@ $ rebar3 sbom
 You can configure additional SBoM metadata in your `rebar.config`:
 
 ```erlang
-{rebar3_sbom, [
+{rebar_sbom, [
     {sbom_manufacturer, #{          % Optional, all fields inside are optional
         name => "Your Organization",
         url => ["https://example.com", "https://another-example.com"],
@@ -147,7 +147,7 @@ You can use either the standard CycloneDX type names or the community convention
 Development
 -----------
 
-To run the full test suite locally, you need the CycloneDX CLI (`cyclonedx-cli`) available on your `PATH`, as it is used by `rebar3_sbom_validation_SUITE` to validate generated SBOMs.
+To run the full test suite locally, you need the CycloneDX CLI (`cyclonedx-cli`) available on your `PATH`, as it is used by `rebar_sbom_validation_SUITE` to validate generated SBOMs.
 
 For example, on macOS or Linux with Homebrew:
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 # Rebar3 SBoM
 
 [![EEF Security WG project](https://img.shields.io/badge/EEF-Security-black)](https://github.com/erlef/security-wg)
-[![.github/workflows/branch_main.yml](https://github.com/erlef/rebar_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/erlef/rebar_sbom/actions/workflows/branch_main.yml)
-[![REUSE status](https://api.reuse.software/badge/github.com/erlef/rebar_sbom)](https://api.reuse.software/info/github.com/erlef/rebar_sbom)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/erlef/rebar_sbom/badge)](https://scorecard.dev/viewer/?uri=github.com/erlef/rebar_sbom)
-[![Coverage Status](https://coveralls.io/repos/github/erlef/rebar_sbom/badge.svg?branch=main)](https://coveralls.io/github/erlef/rebar_sbom?branch=main)
+[![.github/workflows/branch_main.yml](https://github.com/stritzinger/rebar_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/stritzinger/rebar_sbom/actions/workflows/branch_main.yml)
+[![REUSE status](https://api.reuse.software/badge/github.com/stritzinger/rebar_sbom)](https://api.reuse.software/info/github.com/stritzinger/rebar_sbom)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/stritzinger/rebar_sbom/badge)](https://scorecard.dev/viewer/?uri=github.com/stritzinger/rebar_sbom)
+[![Coverage Status](https://coveralls.io/repos/github/stritzinger/rebar_sbom/badge.svg?branch=main)](https://coveralls.io/github/stritzinger/rebar_sbom?branch=main)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11547/badge)](https://www.bestpractices.dev/projects/11547)
 
 Generates a Software Bill-of-Materials (SBoM) in CycloneDX format

--- a/include/rebar_sbom.hrl
+++ b/include/rebar_sbom.hrl
@@ -3,7 +3,7 @@
 
 %--- Macros --------------------------------------------------------------------
 
--define(APP, "rebar3_sbom").
+-define(APP, "rebar_sbom").
 -define(DEFAULT_OUTPUT, "./bom.[xml|json]").
 -define(DEFAULT_VERSION, 1).
 -define(PROVIDER, sbom).

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 {ex_doc, [
     {extras, ["README.md"]},
     {main, "README.md"},
-    {source_url, "https://github.com/voltone/rebar_sbom"}
+    {source_url, "https://github.com/stritzinger/rebar_sbom"}
 ]}.
 
 {hex, [{doc, ex_doc}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 {ex_doc, [
     {extras, ["README.md"]},
     {main, "README.md"},
-    {source_url, "https://github.com/voltone/rebar3_sbom"}
+    {source_url, "https://github.com/voltone/rebar_sbom"}
 ]}.
 
 {hex, [{doc, ex_doc}]}.

--- a/src/rebar_sbom.app.src
+++ b/src/rebar_sbom.app.src
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2024 Bram Verburg
 
-{application, rebar3_sbom, [
+{application, rebar_sbom, [
     {description, "Rebar3 plugin to generate CycloneDX SBoM"},
     {vsn, "0.9.0-beta.1"},
     {registered, []},
@@ -13,5 +13,5 @@
     {modules, []},
 
     {licenses, ["BSD-3-Clause"]},
-    {links, [{"GitHub", "https://github.com/voltone/rebar3_sbom"}]}
+    {links, [{"GitHub", "https://github.com/voltone/rebar_sbom"}]}
 ]}.

--- a/src/rebar_sbom.app.src
+++ b/src/rebar_sbom.app.src
@@ -13,5 +13,5 @@
     {modules, []},
 
     {licenses, ["BSD-3-Clause"]},
-    {links, [{"GitHub", "https://github.com/voltone/rebar_sbom"}]}
+    {links, [{"GitHub", "https://github.com/stritzinger/rebar_sbom"}]}
 ]}.

--- a/src/rebar_sbom.erl
+++ b/src/rebar_sbom.erl
@@ -2,9 +2,9 @@
 %% SPDX-FileCopyrightText: 2019 Bram Verburg
 %% SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
--module(rebar3_sbom).
+-module(rebar_sbom).
 
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 
 -export([init/1]).
 
@@ -32,5 +32,5 @@
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    {ok, State1} = rebar3_sbom_prv:init(State),
+    {ok, State1} = rebar_sbom_prv:init(State),
     {ok, State1}.

--- a/src/rebar_sbom_cpe.erl
+++ b/src/rebar_sbom_cpe.erl
@@ -1,12 +1,12 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
 
--module(rebar3_sbom_cpe).
+-module(rebar_sbom_cpe).
 
 -export([cpe/3]).
 
 % Includes
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 
 %--- Macros --------------------------------------------------------------------
 -define(CPE_PREFIX, <<"cpe:", ?CPE_VERSION/binary>>).

--- a/src/rebar_sbom_cyclonedx.erl
+++ b/src/rebar_sbom_cyclonedx.erl
@@ -4,11 +4,11 @@
 %% SPDX-FileCopyrightText: 2024 Stritzinger GmbH
 %% SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
--module(rebar3_sbom_cyclonedx).
+-module(rebar_sbom_cyclonedx).
 
 -export([bom/5, bom/6, uuid/0]).
 
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 
 bom(FileInfo, IsStrictVersion, App, Plugin, MetadataInfo) ->
     bom(FileInfo, IsStrictVersion, App, Plugin, uuid(), MetadataInfo).
@@ -17,10 +17,10 @@ bom({FilePath, _} = FileInfo, IsStrictVersion, App, Plugin, Serial, MetadataInfo
     {AppInfo, RawComponents} = App,
     {PluginInfo, PluginDepsInfo} = Plugin,
     ValidRawComponents = lists:filter(fun(E) -> E =/= undefined end, RawComponents),
-    % Filtering out rebar3_sbom from plugin dependencies to avoid duplicates in output
+    % Filtering out rebar_sbom from plugin dependencies to avoid duplicates in output
     ValidPluginDepsInfo = lists:filter(
         fun(E) ->
-            E =/= undefined andalso proplists:get_value(name, E) =/= <<"rebar3_sbom">>
+            E =/= undefined andalso proplists:get_value(name, E) =/= <<"rebar_sbom">>
         end,
         PluginDepsInfo
     ),
@@ -49,7 +49,7 @@ bom({FilePath, _} = FileInfo, IsStrictVersion, App, Plugin, Serial, MetadataInfo
     App :: proplists:proplist(),
     Plugin :: proplists:proplist(),
     MetadataInfo :: proplists:proplist(),
-    Metadata :: rebar3_sbom:metadata().
+    Metadata :: rebar_sbom:metadata().
 metadata(App, Plugin, MetadataInfo) ->
     #metadata{
         timestamp = calendar:system_time_to_rfc3339(erlang:system_time(second)),
@@ -63,7 +63,7 @@ metadata(App, Plugin, MetadataInfo) ->
 -spec sbom_authors(Author, App) -> Authors when
     Author :: undefined | string(),
     App :: proplists:proplist(),
-    Authors :: [rebar3_sbom:individual()].
+    Authors :: [rebar_sbom:individual()].
 sbom_authors(undefined, App) ->
     case os:getenv("GITHUB_ACTOR") of
         false ->
@@ -77,7 +77,7 @@ sbom_authors(Author, _App) ->
 -spec sbom_licenses(LicensesIn, App) -> LicensesOut when
     LicensesIn :: undefined | [string()],
     App :: proplists:proplist(),
-    LicensesOut :: [rebar3_sbom:license()].
+    LicensesOut :: [rebar_sbom:license()].
 sbom_licenses(undefined, App) ->
     component_field(licenses, App);
 sbom_licenses(Licenses, _App) ->
@@ -138,7 +138,7 @@ component_field(Field, RawComponent) ->
 license(Name) when is_binary(Name) ->
     license(binary:bin_to_list(Name));
 license(Name) ->
-    case rebar3_sbom_license:spdx_id(Name) of
+    case rebar_sbom_license:spdx_id(Name) of
         undefined ->
             #license{name = Name};
         SpdxId ->
@@ -147,7 +147,7 @@ license(Name) ->
 
 -spec manufacturer(ManufacturerIn) -> ManufacturerOut when
     ManufacturerIn :: undefined | map(),
-    ManufacturerOut :: rebar3_sbom:organization() | undefined.
+    ManufacturerOut :: rebar_sbom:organization() | undefined.
 manufacturer(undefined) ->
     undefined;
 manufacturer(Manufacturer) ->
@@ -158,7 +158,7 @@ manufacturer(Manufacturer) ->
         contact = individuals(maps:get(contact, Manufacturer, undefined))
     }.
 
--spec address(undefined | map()) -> undefined | rebar3_sbom:address().
+-spec address(undefined | map()) -> undefined | rebar_sbom:address().
 address(undefined) ->
     undefined;
 address(AddressMap) ->
@@ -173,7 +173,7 @@ address(AddressMap) ->
 
 -spec individuals(IndividualsIn) -> IndividualsOut when
     IndividualsIn :: [string()],
-    IndividualsOut :: [rebar3_sbom:individual()].
+    IndividualsOut :: [rebar_sbom:individual()].
 individuals(undefined) ->
     [];
 individuals(Individuals) ->
@@ -190,7 +190,7 @@ individuals(Individuals) ->
 
 -spec authors(App) -> Authors when
     App :: proplists:proplist(),
-    Authors :: [rebar3_sbom:individual()].
+    Authors :: [rebar_sbom:individual()].
 authors(App) ->
     [#individual{name = Name} || Name <- proplists:get_value(authors, App, [])].
 
@@ -234,8 +234,8 @@ version({FilePath, Format}, IsStrictVersion, NewSBoM) ->
 
 -spec version(IsStrictVersion, {NewSBoM, OldSBoM}) -> Version when
     IsStrictVersion :: boolean(),
-    NewSBoM :: rebar3_sbom:sbom(),
-    OldSBoM :: rebar3_sbom:sbom(),
+    NewSBoM :: rebar_sbom:sbom(),
+    OldSBoM :: rebar_sbom:sbom(),
     Version :: integer().
 version(_, {_, OldSBoM}) when OldSBoM#sbom.version =:= 0 ->
     rebar_api:info(
@@ -267,26 +267,26 @@ is_sbom_equal(#sbom{components = NewComponents}, #sbom{components = OldComponent
         lists:all(fun(C) -> lists:member(C, OldComponents) end, NewComponents).
 
 decode(FilePath, "xml") ->
-    rebar3_sbom_xml:decode(FilePath);
+    rebar_sbom_xml:decode(FilePath);
 decode(FilePath, "json") ->
-    rebar3_sbom_json:decode(FilePath).
+    rebar_sbom_json:decode(FilePath).
 
--spec normalize_sbom(rebar3_sbom:sbom()) -> rebar3_sbom:sbom().
+-spec normalize_sbom(rebar_sbom:sbom()) -> rebar_sbom:sbom().
 normalize_sbom(#sbom{metadata = Metadata0, components = Components0, dependencies = Deps0} = S) ->
     Components = lists:map(fun normalize_component/1, dedup(Components0)),
     Metadata = normalize_metadata(Metadata0),
     Deps = normalize_deps(Deps0),
     S#sbom{metadata = Metadata, components = Components, dependencies = Deps}.
 
--spec normalize_metadata(rebar3_sbom:metadata()) -> rebar3_sbom:metadata().
+-spec normalize_metadata(rebar_sbom:metadata()) -> rebar_sbom:metadata().
 normalize_metadata(#metadata{authors = Authors0, licenses = Licenses0} = M) ->
     M#metadata{authors = dedup(Authors0), licenses = dedup(Licenses0)}.
 
--spec normalize_component(rebar3_sbom:component()) -> rebar3_sbom:component().
+-spec normalize_component(rebar_sbom:component()) -> rebar_sbom:component().
 normalize_component(#component{authors = Authors0, licenses = Licenses0} = C) ->
     C#component{authors = dedup(Authors0), licenses = dedup(Licenses0)}.
 
--spec normalize_deps([rebar3_sbom:dependency()]) -> [rebar3_sbom:dependency()].
+-spec normalize_deps([rebar_sbom:dependency()]) -> [rebar_sbom:dependency()].
 normalize_deps(Deps0) ->
     Deps1 = [D#dependency{dependencies = normalize_deps(D#dependency.dependencies)} || D <- Deps0],
     dedup(Deps1).

--- a/src/rebar_sbom_json.erl
+++ b/src/rebar_sbom_json.erl
@@ -2,11 +2,11 @@
 %% SPDX-FileCopyrightText: 2024 Stritzinger GmbH
 %% SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
--module(rebar3_sbom_json).
+-module(rebar_sbom_json).
 
 -export([encode/1, decode/1]).
 
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 
 -define(SCHEMA, <<"http://cyclonedx.org/schema/bom-1.6.schema.json">>).
 
@@ -62,11 +62,11 @@ component_to_json(C) ->
 prune_content(Component) ->
     maps:filter(fun(_, Value) -> Value =/= undefined end, Component).
 
--spec individuals_to_json([rebar3_sbom:individual()]) -> [#{name => binary()}].
+-spec individuals_to_json([rebar_sbom:individual()]) -> [#{name => binary()}].
 individuals_to_json(Individuals) ->
     [individual_to_json(I) || I <- Individuals].
 
--spec individual_to_json(rebar3_sbom:individual()) -> #{name => binary()}.
+-spec individual_to_json(rebar_sbom:individual()) -> #{name => binary()}.
 individual_to_json(Individual) ->
     prune_content(#{
         name => bin(Individual#individual.name),
@@ -74,7 +74,7 @@ individual_to_json(Individual) ->
         phone => bin(Individual#individual.phone)
     }).
 
--spec metadata_to_json(rebar3_sbom:metadata()) -> map().
+-spec metadata_to_json(rebar_sbom:metadata()) -> map().
 metadata_to_json(Metadata) ->
     prune_content(#{
         timestamp => bin(Metadata#metadata.timestamp),
@@ -85,7 +85,7 @@ metadata_to_json(Metadata) ->
         licenses => licenses_to_json(Metadata#metadata.licenses)
     }).
 
--spec manufacturer_to_json(rebar3_sbom:organization() | undefined) -> map() | undefined.
+-spec manufacturer_to_json(rebar_sbom:organization() | undefined) -> map() | undefined.
 manufacturer_to_json(undefined) ->
     undefined;
 manufacturer_to_json(Manufacturer) ->
@@ -96,7 +96,7 @@ manufacturer_to_json(Manufacturer) ->
         contact => individuals_to_json(Manufacturer#organization.contact)
     }).
 
--spec address_to_json(rebar3_sbom:address()) -> map().
+-spec address_to_json(rebar_sbom:address()) -> map().
 address_to_json(Address) ->
     prune_content(#{
         country => bin(Address#address.country),

--- a/src/rebar_sbom_license.erl
+++ b/src/rebar_sbom_license.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2019 Bram Verburg
 
--module(rebar3_sbom_license).
+-module(rebar_sbom_license).
 
 -export([spdx_id/1]).
 

--- a/src/rebar_sbom_prv.erl
+++ b/src/rebar_sbom_prv.erl
@@ -5,11 +5,11 @@
 %% SPDX-FileCopyrightText: 2024 Paulo F. Oliveira
 %% SPDX-FileCopyrightText: 2024-2026 Stritzinger GmbH
 
--module(rebar3_sbom_prv).
+-module(rebar_sbom_prv).
 
 -export([init/1, do/1, format_error/1]).
 
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 
 %--- Macros --------------------------------------------------------------------
 -define(CUSTOM_MAPPING, #{
@@ -64,7 +64,7 @@ do(State) ->
     PluginDeps = rebar_state:all_plugin_deps(State),
     {value, Plugin} = lists:search(
         fun(Plugin) ->
-            rebar_app_info:name(Plugin) =:= <<"rebar3_sbom">>
+            rebar_app_info:name(Plugin) =:= <<"rebar_sbom">>
         end,
         PluginDeps
     ),
@@ -76,7 +76,7 @@ do(State) ->
     AppInfo = dep_info(App),
     AppInfo2 = [{sha256, hash(AppInfo, rebar_dir:base_dir(State))} | AppInfo],
     MetadataInfo = metadata(State),
-    SBoM = rebar3_sbom_cyclonedx:bom(
+    SBoM = rebar_sbom_cyclonedx:bom(
         {FilePath, Format},
         IsStrictVersion,
         {AppInfo2, DepsInfo},
@@ -85,8 +85,8 @@ do(State) ->
     ),
     Contents =
         case Format of
-            "xml" -> rebar3_sbom_xml:encode(SBoM);
-            "json" -> rebar3_sbom_json:encode(SBoM)
+            "xml" -> rebar_sbom_xml:encode(SBoM);
+            "json" -> rebar_sbom_json:encode(SBoM)
         end,
     case write_file(FilePath, Contents, Force) of
         ok ->
@@ -103,7 +103,7 @@ format_error(Message) ->
 -spec metadata(rebar_state:t()) -> proplists:proplist().
 metadata(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
-    PluginOpts = rebar_state:get(State, rebar3_sbom, []),
+    PluginOpts = rebar_state:get(State, rebar_sbom, []),
     Manufacturer = proplists:get_value(sbom_manufacturer, PluginOpts, undefined),
     Licenses = proplists:get_value(sbom_licenses, PluginOpts, undefined),
     [
@@ -260,9 +260,9 @@ dep_info(_Name, _Version, {pkg, Name, Version, Sha256}, Common) ->
     [
         {name, Name},
         {version, Version},
-        {purl, rebar3_sbom_purl:hex(Name, Version)},
+        {purl, rebar_sbom_purl:hex(Name, Version)},
         {sha256, string:lowercase(Sha256)},
-        {cpe, rebar3_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
+        {cpe, rebar_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
         | Common
     ];
 dep_info(_Name, _Version, {pkg, Name, Version, _InnerChecksum, OuterChecksum, _RepoConf}, Common) ->
@@ -270,25 +270,25 @@ dep_info(_Name, _Version, {pkg, Name, Version, _InnerChecksum, OuterChecksum, _R
     [
         {name, Name},
         {version, Version},
-        {purl, rebar3_sbom_purl:hex(Name, Version)},
+        {purl, rebar_sbom_purl:hex(Name, Version)},
         {sha256, string:lowercase(OuterChecksum)},
-        {cpe, rebar3_sbom_cpe:cpe(Name, Version, GitHubLink)}
+        {cpe, rebar_sbom_cpe:cpe(Name, Version, GitHubLink)}
         | Common
     ];
 dep_info(Name, _DepVersion, {git, Git, GitRef}, Common) ->
     {Version, Purl, CPE} =
         case GitRef of
             {tag, Tag} ->
-                GeneratedCPE = rebar3_sbom_cpe:cpe(Name, list_to_binary(Tag), list_to_binary(Git)),
-                {Tag, rebar3_sbom_purl:git(Name, Git, Tag), GeneratedCPE};
+                GeneratedCPE = rebar_sbom_cpe:cpe(Name, list_to_binary(Tag), list_to_binary(Git)),
+                {Tag, rebar_sbom_purl:git(Name, Git, Tag), GeneratedCPE};
             {branch, Branch} ->
-                GeneratedCPE = rebar3_sbom_cpe:cpe(
+                GeneratedCPE = rebar_sbom_cpe:cpe(
                     Name, list_to_binary(Branch), list_to_binary(Git)
                 ),
-                {Branch, rebar3_sbom_purl:git(Name, Git, Branch), GeneratedCPE};
+                {Branch, rebar_sbom_purl:git(Name, Git, Branch), GeneratedCPE};
             {ref, Ref} ->
-                GeneratedCPE = rebar3_sbom_cpe:cpe(Name, list_to_binary(Ref), list_to_binary(Git)),
-                {Ref, rebar3_sbom_purl:git(Name, Git, Ref), GeneratedCPE}
+                GeneratedCPE = rebar_sbom_cpe:cpe(Name, list_to_binary(Ref), list_to_binary(Git)),
+                {Ref, rebar_sbom_purl:git(Name, Git, Ref), GeneratedCPE}
         end,
     [
         {name, Name},
@@ -304,18 +304,18 @@ dep_info(Name, Version, checkout, Common) ->
     [
         {name, Name},
         {version, Version},
-        {purl, rebar3_sbom_purl:local_otp_app(Name, Version)},
-        {cpe, rebar3_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
+        {purl, rebar_sbom_purl:local_otp_app(Name, Version)},
+        {cpe, rebar_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
         | Common
     ];
 dep_info(Name, Version, root_app, Common) ->
     GitHubLink = proplists:get_value(github_link, Common, undefined),
-    Purl = rebar3_sbom_purl:hex(Name, Version),
+    Purl = rebar_sbom_purl:hex(Name, Version),
     [
         {name, Name},
         {version, Version},
         {purl, Purl},
-        {cpe, rebar3_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
+        {cpe, rebar_sbom_cpe:cpe(Name, list_to_binary(Version), GitHubLink)}
         | Common
     ].
 

--- a/src/rebar_sbom_purl.erl
+++ b/src/rebar_sbom_purl.erl
@@ -4,7 +4,7 @@
 %% SPDX-FileCopyrightText: 2024 Sebastian Strollo
 %% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
 
--module(rebar3_sbom_purl).
+-module(rebar_sbom_purl).
 
 % https://github.com/package-url/purl-spec
 

--- a/src/rebar_sbom_xml.erl
+++ b/src/rebar_sbom_xml.erl
@@ -1,11 +1,11 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2024 Stritzinger GmbH
 
--module(rebar3_sbom_xml).
+-module(rebar_sbom_xml).
 
 -export([encode/1, decode/1]).
 
--include("rebar3_sbom.hrl").
+-include("rebar_sbom.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 -define(XMLNS, "http://cyclonedx.org/schema/bom/1.6").

--- a/test/basic_app/rebar.config
+++ b/test/basic_app/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{rebar3_sbom, [
+{rebar_sbom, [
     {sbom_manufacturer, #{
         name => "The comunity of the Ring",
         address => #{

--- a/test/basic_app/src/basic_app.app.src
+++ b/test/basic_app/src/basic_app.app.src
@@ -1,5 +1,5 @@
 {application, basic_app, [
-    {description, "Basic app for testing rebar3_sbom"},
+    {description, "Basic app for testing rebar_sbom"},
     {vsn, "0.1.0"},
     {registered, []},
     {mod, {basic_app_app, []}},

--- a/test/local_app/rebar.config
+++ b/test/local_app/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{rebar3_sbom, [
+{rebar_sbom, [
 ]}.
 
 {deps, [

--- a/test/local_app/src/local_app.app.src
+++ b/test/local_app/src/local_app.app.src
@@ -1,5 +1,5 @@
 {application, local_app, [
-    {description, "Application with local dependencies for testing rebar3_sbom"},
+    {description, "Application with local dependencies for testing rebar_sbom"},
     {vsn, "0.1.0"},
     {registered, []},
     {mod, {local_app_app, []}},

--- a/test/rebar_sbom_cpe_SUITE.erl
+++ b/test/rebar_sbom_cpe_SUITE.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
 
--module(rebar3_sbom_cpe_SUITE).
+-module(rebar_sbom_cpe_SUITE).
 
 % CT Exports
 -export([all/0]).
@@ -57,69 +57,69 @@ end_per_testcase(_, _Config) ->
 %--- Test cases ----------------------------------------------------------------
 
 hex_core_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"hex_core">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"hex_core">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:hex:hex_core:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"hex_core">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"hex_core">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:hex:hex_core:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 plug_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"plug">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"plug">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-plug:plug:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"plug">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"plug">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-plug:plug:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 phoenix_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"phoenix">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"phoenix">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:phoenixframework:phoenix:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"phoenix">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"phoenix">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:phoenixframework:phoenix:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 coherence_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"coherence">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"coherence">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:coherence_project:coherence:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"coherence">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"coherence">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:coherence_project:coherence:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 xain_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"xain">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"xain">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:emetrotel:xain:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"xain">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"xain">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:emetrotel:xain:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 sweet_xml_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"sweet_xml">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"sweet_xml">>, <<"1.0.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:kbrw:sweet_xml:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"sweet_xml">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"sweet_xml">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:kbrw:sweet_xml:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 erlang_otp_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"erlang/otp">>, <<"28.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"erlang/otp">>, <<"28.0">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:erlang\/otp:28.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"erlang/otp">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"erlang/otp">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:erlang\/otp:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 rebar3_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"rebar3">>, <<"3.14.1">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"rebar3">>, <<"3.14.1">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:rebar3:3.14.1:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"rebar3">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"rebar3">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:erlang:rebar3:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 elixir_cpe_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"elixir">>, <<"1.19.3">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"elixir">>, <<"1.19.3">>, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-lang:elixir:1.19.3:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(<<"elixir">>, undefined, undefined),
+    CPENoVersion = rebar_sbom_cpe:cpe(<<"elixir">>, undefined, undefined),
     ?assertEqual(<<"cpe:2.3:a:elixir-lang:elixir:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 default_behavior_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(
+    CPE = rebar_sbom_cpe:cpe(
         <<"my_package">>, <<"1.0.0">>, <<"https://github.com/my_org/my_package">>
     ),
     ?assertEqual(<<"cpe:2.3:a:my_org:my_package:1.0.0:*:*:*:*:*:*:*">>, CPE),
-    CPENoVersion = rebar3_sbom_cpe:cpe(
+    CPENoVersion = rebar_sbom_cpe:cpe(
         <<"my_package">>, undefined, <<"https://github.com/my_org/my_package">>
     ),
     ?assertEqual(<<"cpe:2.3:a:my_org:my_package:*:*:*:*:*:*:*:*">>, CPENoVersion).
 
 no_url_test(_) ->
-    CPE = rebar3_sbom_cpe:cpe(<<"non_hex_package">>, <<"1.0.0">>, undefined),
+    CPE = rebar_sbom_cpe:cpe(<<"non_hex_package">>, <<"1.0.0">>, undefined),
     ?assertEqual(undefined, CPE).

--- a/test/rebar_sbom_json_SUITE.erl
+++ b/test/rebar_sbom_json_SUITE.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025-2026 Stritzinger GmbH
 
--module(rebar3_sbom_json_SUITE).
+-module(rebar_sbom_json_SUITE).
 
 % CT Exports
 -export([all/0, groups/0]).
@@ -54,7 +54,7 @@
 % Includes
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
--include_lib("rebar3_sbom/include/rebar3_sbom.hrl").
+-include_lib("rebar_sbom/include/rebar_sbom.hrl").
 
 % Macros
 -define(SERIAL_NB_REGEX, "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$").
@@ -196,9 +196,9 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    application:load(rebar3_sbom),
-    {ok, PluginVersion} = application:get_key(rebar3_sbom, vsn),
-    {ok, PluginDescription} = application:get_key(rebar3_sbom, description),
+    application:load(rebar_sbom),
+    {ok, PluginVersion} = application:get_key(rebar_sbom, vsn),
+    {ok, PluginDescription} = application:get_key(rebar_sbom, description),
     [
         {plugin_version, list_to_binary(PluginVersion)},
         {plugin_description, list_to_binary(PluginDescription)}
@@ -209,7 +209,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_group(basic_app, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     PrivDir = ?config(priv_dir, Config),
     SBoMPath = filename:join(PrivDir, ?BASIC_APP_SBOM),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-a", "Jane Doe"],
@@ -226,7 +226,7 @@ init_per_group(basic_app, Config) ->
 init_per_group(basic_app_with_sbom, Config) ->
     % makes sure that new generated TS must be different
     timer:sleep(1000),
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
     {ok, _FinalState} = rebar3:run(State, Cmd),
@@ -237,7 +237,7 @@ init_per_group(metadata, Config) ->
     #{<<"metadata">> := Metadata} = ?config(sbom_json, Config),
     [{metadata, Metadata} | Config];
 init_per_group(local_app, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "local_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "local_app"),
     PrivDir = ?config(priv_dir, Config),
     SBoMPath = filename:join(PrivDir, ?LOCAL_APP_SBOM),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
@@ -254,14 +254,14 @@ end_per_group(GroupName, Config) when
     DataDir = ?config(data_dir, Config),
     case GroupName of
         basic_app ->
-            AppDir = rebar3_sbom_test_utils:get_app_dir(DataDir, "basic_app"),
+            AppDir = rebar_sbom_test_utils:get_app_dir(DataDir, "basic_app"),
             file:delete(filename:join(AppDir, "rebar.lock")),
-            BuildDir = rebar3_sbom_test_utils:build_dir_path(DataDir, "basic_app"),
+            BuildDir = rebar_sbom_test_utils:build_dir_path(DataDir, "basic_app"),
             file:delete(BuildDir);
         local_app ->
-            AppDir = rebar3_sbom_test_utils:get_app_dir(DataDir, "local_app"),
+            AppDir = rebar_sbom_test_utils:get_app_dir(DataDir, "local_app"),
             file:delete(filename:join(AppDir, "rebar.lock")),
-            BuildDir = rebar3_sbom_test_utils:build_dir_path(DataDir, "local_app"),
+            BuildDir = rebar_sbom_test_utils:build_dir_path(DataDir, "local_app"),
             file:delete(BuildDir)
     end;
 end_per_group(_, _Config) ->
@@ -269,7 +269,7 @@ end_per_group(_, _Config) ->
 
 init_per_testcase(github_actor_test, Config) ->
     os:putenv("GITHUB_ACTOR", "Bilbo Baggins"),
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
     {ok, _FinalState} = rebar3:run(State, Cmd),
@@ -277,7 +277,7 @@ init_per_testcase(github_actor_test, Config) ->
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON} | Config];
 init_per_testcase(default_author_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
     {ok, _FinalState} = rebar3:run(State, Cmd),
@@ -285,8 +285,8 @@ init_per_testcase(default_author_test, Config) ->
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON} | Config];
 init_per_testcase(empty_manufacturer_url_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
-    PluginOpts = rebar_state:get(State, rebar3_sbom),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    PluginOpts = rebar_state:get(State, rebar_sbom),
     Manufacturer = proplists:get_value(sbom_manufacturer, PluginOpts),
     NewPluginOpts = lists:keyreplace(
         sbom_manufacturer,
@@ -294,7 +294,7 @@ init_per_testcase(empty_manufacturer_url_test, Config) ->
         PluginOpts,
         {sbom_manufacturer, maps:remove(url, Manufacturer)}
     ),
-    State2 = rebar_state:set(State, rebar3_sbom, NewPluginOpts),
+    State2 = rebar_state:set(State, rebar_sbom, NewPluginOpts),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
     {ok, _FinalState} = rebar3:run(State2, Cmd),
@@ -302,8 +302,8 @@ init_per_testcase(empty_manufacturer_url_test, Config) ->
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON} | Config];
 init_per_testcase(manufacturer_empty_url_array_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
-    PluginOpts = rebar_state:get(State, rebar3_sbom),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    PluginOpts = rebar_state:get(State, rebar_sbom),
     Manufacturer = proplists:get_value(sbom_manufacturer, PluginOpts),
     NewPluginOpts = lists:keyreplace(
         sbom_manufacturer,
@@ -311,7 +311,7 @@ init_per_testcase(manufacturer_empty_url_array_test, Config) ->
         PluginOpts,
         {sbom_manufacturer, Manufacturer#{url => []}}
     ),
-    State2 = rebar_state:set(State, rebar3_sbom, NewPluginOpts),
+    State2 = rebar_state:set(State, rebar_sbom, NewPluginOpts),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f"],
     {ok, _FinalState} = rebar3:run(State2, Cmd),
@@ -319,7 +319,7 @@ init_per_testcase(manufacturer_empty_url_array_test, Config) ->
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON} | Config];
 init_per_testcase(metadata_component_hashes_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     SBoMPath = ?config(sbom_path, Config),
     {ok, _} = rebar3:run(State, ["tar"]),
     ExpectedHash = get_tar_hash(?config(priv_dir, Config), "basic_app", "0.1.0"),
@@ -329,7 +329,7 @@ init_per_testcase(metadata_component_hashes_test, Config) ->
     NewSBoMJSON = json:decode(File),
     [{sbom_json, NewSBoMJSON}, {expected_hash, ExpectedHash} | Config];
 init_per_testcase(strict_version_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     SBoMPath = ?config(sbom_path, Config),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "true", "-f"],
     {ok, _FinalState} = rebar3:run(State, Cmd),
@@ -440,7 +440,7 @@ timestamp_test(Config) ->
     ?assert(TsSysTime < SysTimeNow).
 
 tools_test(Config) ->
-    % Assume that in basic_app we only have a component for rebar3_sbom
+    % Assume that in basic_app we only have a component for rebar_sbom
     #{<<"tools">> := Tools} = ?config(metadata, Config),
     ?assertMatch(#{<<"components">> := [_ | _]}, Tools),
     #{<<"components">> := [Tool]} = Tools,
@@ -455,7 +455,7 @@ tools_test(Config) ->
         <<"licenses">> := [License]
     } = Tool,
     ?assertEqual(<<"application">>, Type),
-    ?assertEqual(<<"rebar3_sbom">>, Name),
+    ?assertEqual(<<"rebar_sbom">>, Name),
     check_bom_ref_format(Tool),
     ?assertEqual(?config(plugin_version, Config), Version),
     ?assertEqual(?config(plugin_description, Config), Description),
@@ -463,7 +463,7 @@ tools_test(Config) ->
     check_hashes_constraints(Hashes),
     check_purl_format(Purl),
     % Plugin is in _checkouts for the tests
-    ?assertMatch(<<"pkg:otp/rebar3_sbom", _/bitstring>>, Purl),
+    ?assertMatch(<<"pkg:otp/rebar_sbom", _/bitstring>>, Purl),
     ?assertMatch(#{<<"license">> := #{<<"id">> := <<"BSD-3-Clause">>}}, License).
 
 metadata_authors_test(Config) ->
@@ -498,7 +498,7 @@ component_test(Config) ->
     ?assertEqual(<<"basic_app">>, Name, "metadata.component.name"),
     ?assertEqual(<<"0.1.0">>, Version, "metadata.component.version"),
     ?assertEqual(
-        <<"Basic app for testing rebar3_sbom">>,
+        <<"Basic app for testing rebar_sbom">>,
         Description,
         "metadata.component.description"
     ),

--- a/test/rebar_sbom_json_SUITE.erl
+++ b/test/rebar_sbom_json_SUITE.erl
@@ -339,12 +339,12 @@ init_per_testcase(strict_version_test, Config) ->
 init_per_testcase(git_root_app_source_test, Config) ->
     DataDir = ?config(data_dir, Config),
     PrivDir = ?config(priv_dir, Config),
-    SrcDir = rebar3_sbom_test_utils:get_app_dir(DataDir, "local_app"),
+    SrcDir = rebar_sbom_test_utils:get_app_dir(DataDir, "local_app"),
     AppDir = filename:join(PrivDir, "git_root_app"),
     ok = maybe_delete_dir(AppDir),
     {ok, _} = rebar_utils:sh(["cp -r ", SrcDir, " ", AppDir], []),
     init_git_repo(AppDir, "https://github.com/ExampleOrg/local_app.git"),
-    State = rebar3_sbom_test_utils:init_rebar_state_from_dir(
+    State = rebar_sbom_test_utils:init_rebar_state_from_dir(
         Config, AppDir, "git_root_app"
     ),
     SBoMPath = filename:join(PrivDir, "git_root_app_sbom.json"),

--- a/test/rebar_sbom_purl_SUITE.erl
+++ b/test/rebar_sbom_purl_SUITE.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
 
--module(rebar3_sbom_purl_SUITE).
+-module(rebar_sbom_purl_SUITE).
 
 % CT Exports
 -export([all/0]).
@@ -36,11 +36,11 @@ all() ->
 %--- Test cases ----------------------------------------------------------------
 
 hex_purl_test(_) ->
-    Purl = rebar3_sbom_purl:hex("Rebar3_SBOM", "1.2.3"),
-    ?assertEqual(<<"pkg:hex/rebar3_sbom@1.2.3">>, Purl).
+    Purl = rebar_sbom_purl:hex("Rebar3_SBOM", "1.2.3"),
+    ?assertEqual(<<"pkg:hex/rebar_sbom@1.2.3">>, Purl).
 
 github_purl_test(_) ->
-    Purl = rebar3_sbom_purl:github("ExampleOrg/ExampleRepo", "1.0.0"),
+    Purl = rebar_sbom_purl:github("ExampleOrg/ExampleRepo", "1.0.0"),
     ?assertEqual(<<"pkg:github/exampleorg/examplerepo@1.0.0">>, Purl).
 
 git_github_variants_test(_) ->
@@ -51,14 +51,14 @@ git_github_variants_test(_) ->
     ],
     lists:foreach(
         fun(Url) ->
-            Purl = rebar3_sbom_purl:git("example_app", Url, "3.0.0"),
+            Purl = rebar_sbom_purl:git("example_app", Url, "3.0.0"),
             ?assertEqual(<<"pkg:github/exampleorg/examplerepo@3.0.0">>, Purl)
         end,
         Urls
     ).
 
 bitbucket_purl_test(_) ->
-    Purl = rebar3_sbom_purl:bitbucket("ExampleOrg/ExampleRepo", "2.0.0"),
+    Purl = rebar_sbom_purl:bitbucket("ExampleOrg/ExampleRepo", "2.0.0"),
     ?assertEqual(<<"pkg:bitbucket/exampleorg/examplerepo@2.0.0">>, Purl).
 
 git_bitbucket_variants_test(_) ->
@@ -69,7 +69,7 @@ git_bitbucket_variants_test(_) ->
     ],
     lists:foreach(
         fun(Url) ->
-            Purl = rebar3_sbom_purl:git("example_app", Url, "4.0.0"),
+            Purl = rebar_sbom_purl:git("example_app", Url, "4.0.0"),
             ?assertEqual(<<"pkg:bitbucket/exampleorg/examplerepo@4.0.0">>, Purl)
         end,
         Urls
@@ -78,7 +78,7 @@ git_bitbucket_variants_test(_) ->
 git_unsupported_host_test(_) ->
     ?assertEqual(
         undefined,
-        rebar3_sbom_purl:git(
+        rebar_sbom_purl:git(
             "example_app",
             "git@gitlab.com:ExampleOrg/ExampleRepo.git",
             "5.0.0"
@@ -86,9 +86,9 @@ git_unsupported_host_test(_) ->
     ).
 
 local_otp_app_purl_test(_) ->
-    Purl = rebar3_sbom_purl:local_otp_app("Local-App", "0.9.0"),
+    Purl = rebar_sbom_purl:local_otp_app("Local-App", "0.9.0"),
     ?assertEqual(<<"pkg:otp/local-app@0.9.0">>, Purl).
 
 local_purl_test(_) ->
-    Purl = rebar3_sbom_purl:local("Local-App", "0.9.0"),
+    Purl = rebar_sbom_purl:local("Local-App", "0.9.0"),
     ?assertEqual(<<"pkg:generic/local-app@0.9.0">>, Purl).

--- a/test/rebar_sbom_purl_SUITE.erl
+++ b/test/rebar_sbom_purl_SUITE.erl
@@ -36,7 +36,7 @@ all() ->
 %--- Test cases ----------------------------------------------------------------
 
 hex_purl_test(_) ->
-    Purl = rebar_sbom_purl:hex("Rebar3_SBOM", "1.2.3"),
+    Purl = rebar_sbom_purl:hex("Rebar_SBOM", "1.2.3"),
     ?assertEqual(<<"pkg:hex/rebar_sbom@1.2.3">>, Purl).
 
 github_purl_test(_) ->

--- a/test/rebar_sbom_test_utils.erl
+++ b/test/rebar_sbom_test_utils.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025-2026 Stritzinger GmbH
 
--module(rebar3_sbom_test_utils).
+-module(rebar_sbom_test_utils).
 
 -export([get_app_dir/2]).
 -export([init_rebar_state/2]).
@@ -35,7 +35,7 @@ init_rebar_state_from_dir(Config, AppDir, AppName) ->
     ]),
     RebarConfig = rebar_config:consult(AppDir),
     State2 = rebar_state:new(State, RebarConfig, AppDir),
-    {ok, State3} = rebar3_sbom_prv:init(State2),
+    {ok, State3} = rebar_sbom_prv:init(State2),
     add_fake_plugin_dep(State3, DataDir).
 
 build_dir_path(PrivDir, AppName) ->

--- a/test/rebar_sbom_validation_SUITE.erl
+++ b/test/rebar_sbom_validation_SUITE.erl
@@ -1,7 +1,7 @@
 %% SPDX-License-Identifier: BSD-3-Clause
 %% SPDX-FileCopyrightText: 2025 Stritzinger GmbH
 
--module(rebar3_sbom_validation_SUITE).
+-module(rebar_sbom_validation_SUITE).
 
 % CT Exports
 -export([all/0]).
@@ -30,21 +30,21 @@ all() ->
     ].
 
 init_per_suite(Config) ->
-    application:load(rebar3_sbom),
+    application:load(rebar_sbom),
     [{cyclonedx_cli_path, cyclonedx_cli_path()} | Config].
 
 end_per_suite(Config) ->
     Config.
 
 init_per_testcase(validate_json_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     PrivDir = ?config(priv_dir, Config),
     SBoMPath = filename:join(PrivDir, ?VALIDATION_SBOM_JSON),
     Cmd = ["sbom", "-F", "json", "-o", SBoMPath, "-V", "false", "-f", "-a", "Jane Doe"],
     {ok, _FinalState} = rebar3:run(State, Cmd),
     [{sbom_path, SBoMPath} | Config];
 init_per_testcase(validate_xml_test, Config) ->
-    State = rebar3_sbom_test_utils:init_rebar_state(Config, "basic_app"),
+    State = rebar_sbom_test_utils:init_rebar_state(Config, "basic_app"),
     PrivDir = ?config(priv_dir, Config),
     SBoMPath = filename:join(PrivDir, ?VALIDATION_SBOM_XML),
     Cmd = ["sbom", "-F", "xml", "-o", SBoMPath, "-V", "false", "-f", "-a", "Jane Doe"],


### PR DESCRIPTION
- Use `rebar_sbom` everywhere. 
- Hex docs now point to stritzinger/rebar_sbom
- Adjusted badges to point to this repo url

I would not retouch SPDX headers in this PR, since it is just about renaming